### PR TITLE
Fix workspace path diff for Migration scripts between pods and dev

### DIFF
--- a/src/Altinn.AccessManagement/Program.cs
+++ b/src/Altinn.AccessManagement/Program.cs
@@ -339,7 +339,13 @@ void ConfigurePostgreSql()
         string connectionString = string.Format(
             builder.Configuration.GetValue<string>("PostgreSQLSettings:AdminConnectionString"),
             builder.Configuration.GetValue<string>("PostgreSQLSettings:authorizationDbAdminPwd"));
-        string workspacePath = Path.Combine(Directory.GetParent(Environment.CurrentDirectory).FullName, builder.Configuration.GetValue<string>("PostgreSQLSettings:WorkspacePath"));
+        
+        string workspacePath = Path.Combine(Environment.CurrentDirectory, builder.Configuration.GetValue<string>("PostgreSQLSettings:WorkspacePath"));
+        if (builder.Environment.IsDevelopment())
+        {
+            workspacePath = Path.Combine(Directory.GetParent(Environment.CurrentDirectory).FullName, builder.Configuration.GetValue<string>("PostgreSQLSettings:WorkspacePath"));
+        }
+
         app.UseYuniql(
             new PostgreSqlDataService(traceService),
             new PostgreSqlBulkImportService(traceService),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Migration script folder has been moved from AccessManagement to Persistance project folder.

Docker file copy correctly from it's new location but changes in Program.cs for reading the scripts at runtime will differ when running locally on dev vs aks pods, where Dev need to navigate through parent folder.

## Related Issue(s)
- #184 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
