### PR TITLE
Fix for Resource Registry service mock data having 2022 ValidTo date

### DIFF
--- a/test/Altinn.AccessManagement.Tests/Data/ResourceRegistryResources/digdirs_company_car/resource.json
+++ b/test/Altinn.AccessManagement.Tests/Data/ResourceRegistryResources/digdirs_company_car/resource.json
@@ -18,7 +18,7 @@
   "homepage": "https://www.jksfirmabiler.no/",
   "status": "Active",
   "validFrom": "2022-09-20T06:46:07.598Z",
-  "validTo": "2022-12-24T23:59:59",
+  "validTo": "2099-12-24T23:59:59",
   "isPartOf": "jk_ressurser",
   "isPublicService": true,
   "thematicArea": "http://publications.europa.eu/resource/authority/eurovoc/2468",

--- a/test/Altinn.AccessManagement.Tests/Data/ResourceRegistryResources/jks_audi_etron_gt/resource.json
+++ b/test/Altinn.AccessManagement.Tests/Data/ResourceRegistryResources/jks_audi_etron_gt/resource.json
@@ -18,7 +18,7 @@
   "homepage": "https://www.jksaudi.no/",
   "status": "Active",
   "validFrom": "2022-09-20T06:46:07.598Z",
-  "validTo": "2022-12-24T23:59:59",
+  "validTo": "2099-12-24T23:59:59",
   "isPartOf": "jk_ressurser",
   "isPublicService": true,
   "thematicArea": "http://publications.europa.eu/resource/authority/eurovoc/2468",


### PR DESCRIPTION
## Description
- Increased mock data ValidTo date to 2099 to fix broken integration tests
