### PR TITLE
Turn DB connection back on and fix db deploy for removal of resourcestatus column

### DIFF
--- a/src/Altinn.AccessManagement.Persistence/Migration/v0.07-accessmanagement/02-setup-tables.sql
+++ b/src/Altinn.AccessManagement.Persistence/Migration/v0.07-accessmanagement/02-setup-tables.sql
@@ -13,7 +13,7 @@ TABLESPACE pg_default;
 CREATE INDEX IF NOT EXISTS idx_resource_resourcereferenceid
   ON accessmanagement.resource USING btree
   (resourceRegistryId COLLATE pg_catalog."default" ASC NULLS LAST)
-  INCLUDE(resourceType, resourceStatus)
+  INCLUDE(resourceType)
   TABLESPACE pg_default;
 
 -- Table: delegation.ResourceRegistryDelegationChanges

--- a/src/Altinn.AccessManagement.Persistence/Migration/v0.09-accessmanagement/02-setup-tables.sql
+++ b/src/Altinn.AccessManagement.Persistence/Migration/v0.09-accessmanagement/02-setup-tables.sql
@@ -2,6 +2,13 @@
 ALTER TABLE accessmanagement.resource
 DROP COLUMN IF EXISTS resourcestatus;
 
+-- Index: dropping resourcestatus will automatically drop the index idx_resource_resourcereferenceid and must be recreated without the resourcestatus
+CREATE INDEX IF NOT EXISTS idx_resource_resourcereferenceid
+  ON accessmanagement.resource USING btree
+  (resourceRegistryId COLLATE pg_catalog."default" ASC NULLS LAST)
+  INCLUDE(resourceType)
+  TABLESPACE pg_default;
+
 -- A drop create as there is no "add constraint if not exists" this is just for local dev where changes to yuniql db can be performed.
 ALTER TABLE accessmanagement.resource
 DROP CONSTRAINT IF EXISTS unique_resourceregisterid;

--- a/src/Altinn.AccessManagement/appsettings.json
+++ b/src/Altinn.AccessManagement/appsettings.json
@@ -24,7 +24,7 @@
     "SubscriptionKeyHeaderName": "Ocp-Apim-Subscription-Key"
   },
   "PostgreSQLSettings": {
-    "EnableDBConnection": "false",
+    "EnableDBConnection": "true",
     "WorkspacePath": "Migration",
     "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_authorization_admin;Password={0};Database=authorizationdb",
     "ConnectionString": "Host=localhost;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb",


### PR DESCRIPTION
Turn DB connection back on and fix db deploy for removal of resourcestatus column

## Description
- EnableDBConnection again
- remove resourceStatus column also from index in existing v07 script (meaning for clean deploy will not be created and then dropped again, eg. in TT02 and Prod)
- Since drop of column in v09 script will auto drop the index on the table it will need to recreate the index with just the type column

## Related Issue(s)
- #233

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
