### PR TITLE
Fix sbl buildversion check that incorrectly skips a K6 test

### DIFF
--- a/test/K6/src/Helpers/TestdataHelper.js
+++ b/test/K6/src/Helpers/TestdataHelper.js
@@ -125,7 +125,7 @@ export function deleteAllRules(altinnToken, performedByUserId, offeredByPartyId,
 
 export function minimumSBLVersion(major, minor) {
   var altinnBuildVersion = setUpData.getSBLBuildVersion(); 
-  if (altinnBuildVersion.split('.')[0] >= major && altinnBuildVersion.split('.')[1] >= minor) {
+  if (altinnBuildVersion.split('.')[0] > major || altinnBuildVersion.split('.')[0] == major && altinnBuildVersion.split('.')[1] >= minor) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Description
Some K6 tests can only be run on a certain sbl build version or higher, and the function that does the comparison will sometimes give return false when it should return true.

As an example, the current build is 23.1, and the function checks if it is higher than 22.5. It compares the major and minor versions separately, so even if the major version is higher (23 > 22), it returns false because the minor version is lower (1 < 5). Added a fix where if the major version is higher it returns true, while if it is equal, then it will check the minor version.



## Related Issue(s)
- #265 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
