### PR TITLE
Updated route to match apimanagement setup

### DIFF
--- a/src/Altinn.AccessManagement/Controllers/AuthenticationController.cs
+++ b/src/Altinn.AccessManagement/Controllers/AuthenticationController.cs
@@ -12,7 +12,6 @@ namespace Altinn.AccessManagement.Controllers
     /// <summary>
     /// Exposes API endpoints related to authentication.
     /// </summary>
-    [Route("accessmanagement/")]
     [ApiController]
     [AutoValidateAntiforgeryTokenIfAuthCookie]
     public class AuthenticationController : ControllerBase
@@ -43,7 +42,7 @@ namespace Altinn.AccessManagement.Controllers
         /// </summary>
         /// <returns>Ok result with updated token.</returns>
         [Authorize]
-        [HttpGet("api/v1/authentication/refresh")]
+        [HttpGet("accessmanagement/api/v1/authentication/refresh")]
         public async Task<IActionResult> Refresh()
         {
             try

--- a/src/Altinn.AccessManagement/Controllers/HomeController.cs
+++ b/src/Altinn.AccessManagement/Controllers/HomeController.cs
@@ -12,10 +12,8 @@ namespace Altinn.AccessManagement
     /// <summary>
     /// HomeController
     /// </summary>
-    [Route("accessmanagement/")]
-    [Route("accessmanagement/ui")]
-    [Route("accessmanagement/ui/{*AnyValue}")]
-
+    [ApiController]
+    [Route("accessmanagement/api/v1/accessmanagement/ui/{*AnyValue}")]
     public class HomeController : Controller
     {
         private readonly IAntiforgery _antiforgery;


### PR DESCRIPTION
As accessmanagement is set to deploy under api/v1, as a temporary solution i have updated the route to match the apimanagement route.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
