### PR TITLE
Removed unnecessary lookup call to resource registry from internal WritePolicy operations

### DIFF
--- a/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IDelegationMetadataRepository.cs
+++ b/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IDelegationMetadataRepository.cs
@@ -12,9 +12,10 @@ namespace Altinn.AccessManagement.Core.Repositories.Interfaces
         /// <summary>
         /// Writes the delegation change metadata to the delegation database
         /// </summary>
+        /// <param name="resourceMatchType">The resource match type specifying whether the lookup is for an Altinn App delegation or a resource from the Resource Registry</param>
         /// <param name="delegationChange">The DelegationChange model describing the delegation, to insert in the database</param>
         /// <returns>The complete DelegationChange record stored in the database</returns>
-        Task<DelegationChange> InsertDelegation(DelegationChange delegationChange);
+        Task<DelegationChange> InsertDelegation(ResourceAttributeMatchType resourceMatchType, DelegationChange delegationChange);
 
         /// <summary>
         /// Gets the latest delegation change matching the filter values

--- a/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
+++ b/src/Altinn.AccessManagement.Core/Services/PolicyAdministrationPoint.cs
@@ -1,10 +1,8 @@
 ﻿using System.Net;
 using System.Text.Json;
-using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Enums;
 using Altinn.AccessManagement.Core.Helpers;
 using Altinn.AccessManagement.Core.Models;
-using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Core.Services.Interfaces;
 using Altinn.Authorization.ABAC.Xacml;
@@ -25,7 +23,6 @@ namespace Altinn.AccessManagement.Core.Services
         private readonly IDelegationMetadataRepository _delegationRepository;
         private readonly IDelegationChangeEventQueue _eventQueue;
         private readonly int delegationChangeEventQueueErrorId = 911;
-        private readonly IResourceRegistryClient _resourceRegistryClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolicyAdministrationPoint"/> class.
@@ -35,15 +32,13 @@ namespace Altinn.AccessManagement.Core.Services
         /// <param name="delegationRepository">The delegation change repository (postgresql).</param>
         /// <param name="eventQueue">The delegation change event queue service to post events for any delegation change.</param>
         /// <param name="logger">Logger instance.</param>
-        /// <param name="resourceRegistryClient">Client for accessing the resourceregistry.</param>
-        public PolicyAdministrationPoint(IPolicyRetrievalPoint policyRetrievalPoint, IPolicyRepository policyRepository, IDelegationMetadataRepository delegationRepository, IDelegationChangeEventQueue eventQueue, ILogger<IPolicyAdministrationPoint> logger, IResourceRegistryClient resourceRegistryClient)
+        public PolicyAdministrationPoint(IPolicyRetrievalPoint policyRetrievalPoint, IPolicyRepository policyRepository, IDelegationMetadataRepository delegationRepository, IDelegationChangeEventQueue eventQueue, ILogger<IPolicyAdministrationPoint> logger)
         {
             _prp = policyRetrievalPoint;
             _policyRepository = policyRepository;
             _delegationRepository = delegationRepository;
             _eventQueue = eventQueue;
             _logger = logger;
-            _resourceRegistryClient = resourceRegistryClient;
         }
 
         /// <inheritdoc/>
@@ -392,7 +387,6 @@ namespace Altinn.AccessManagement.Core.Services
 
         private async Task<List<Rule>> DeleteAllRulesInPolicy(RequestToDelete policyToDelete)
         {
-            ServiceResource resourceRegistryService = null;
             string coveredBy = DelegationHelper.GetCoveredByFromMatch(policyToDelete.PolicyMatch.CoveredBy, out int? coveredByUserId, out int? coveredByPartyId);
 
             if (!DelegationHelper.TryGetResourceFromAttributeMatch(policyToDelete.PolicyMatch.Resource, out ResourceAttributeMatchType resourceMatchType, out string resourceId, out string org, out string app))

--- a/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepository.cs
+++ b/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepository.cs
@@ -53,9 +53,9 @@ namespace Altinn.AccessManagement.Persistence
         }
 
         /// <inheritdoc/>
-        public async Task<DelegationChange> InsertDelegation(DelegationChange delegationChange)
+        public async Task<DelegationChange> InsertDelegation(ResourceAttributeMatchType resourceMatchType, DelegationChange delegationChange)
         {
-            if (delegationChange.ResourceType == ResourceAttributeMatchType.AltinnAppId.ToString())
+            if (resourceMatchType == ResourceAttributeMatchType.AltinnAppId)
             {
                 return await InsertAppDelegation(delegationChange);
             }

--- a/src/Altinn.AccessManagement/Controllers/DelegationsController.cs
+++ b/src/Altinn.AccessManagement/Controllers/DelegationsController.cs
@@ -60,7 +60,7 @@ namespace Altinn.AccessManagement.Controllers
         /// <response code="400">Bad Request</response>
         /// <response code="500">Internal Server Error</response>
         [HttpPost]
-        /// [Authorize(Policy = AuthzConstants.ALTINNII_AUTHORIZATION)]
+        [Authorize(Policy = AuthzConstants.ALTINNII_AUTHORIZATION)]
         [Route("accessmanagement/api/v1/delegations/addrules")]
         public async Task<ActionResult> Post([FromBody] List<Rule> rules)
         {

--- a/test/Altinn.AccessManagement.Tests/Mocks/DelegationMetadataRepositoryMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/DelegationMetadataRepositoryMock.cs
@@ -31,13 +31,13 @@ namespace Altinn.AccessManagement.Tests.Mocks
         }
 
         /// <inheritdoc/>
-        public Task<DelegationChange> InsertDelegation(DelegationChange delegationChange)
+        public Task<DelegationChange> InsertDelegation(ResourceAttributeMatchType resourceMatchType, DelegationChange delegationChange)
         {
             List<DelegationChange> current;
             string coveredBy = delegationChange.CoveredByPartyId != null ? $"p{delegationChange.CoveredByPartyId}" : $"u{delegationChange.CoveredByUserId}";
             string key = string.Empty;
 
-            if (delegationChange.ResourceType.Equals(ResourceAttributeMatchType.AltinnAppId.ToString()))
+            if (resourceMatchType == ResourceAttributeMatchType.AltinnAppId)
             {
                 key = $"{delegationChange.ResourceId}/{delegationChange.OfferedByPartyId}/{coveredBy}";
             }
@@ -61,7 +61,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
                 DelegationChangeId = 1337,
                 DelegationChangeType = delegationChange.DelegationChangeType,
                 ResourceId = delegationChange.ResourceId,
-                ResourceType = delegationChange.ResourceType,
+                ResourceType = resourceMatchType == ResourceAttributeMatchType.AltinnAppId ? ResourceAttributeMatchType.AltinnAppId.ToString() : ResourceType.MaskinportenSchema.ToString(),
                 OfferedByPartyId = delegationChange.OfferedByPartyId,
                 CoveredByPartyId = delegationChange.CoveredByPartyId,
                 CoveredByUserId = delegationChange.CoveredByUserId,

--- a/test/Altinn.AccessManagement.Tests/PolicyAdministrationPointTest.cs
+++ b/test/Altinn.AccessManagement.Tests/PolicyAdministrationPointTest.cs
@@ -31,7 +31,6 @@ namespace Altinn.AccessManagement.Tests
         private readonly IDelegationChangeEventQueue _eventQueue;
         private readonly Mock<ILogger<IPolicyAdministrationPoint>> _logger;
         private DelegationMetadataRepositoryMock _delegationMetadataRepositoryMock;
-        private readonly ResourceRegistryClientMock _resourceRegistryClientMock = new ResourceRegistryClientMock();
 
         /// <summary>
         /// Constructor setting up dependencies
@@ -53,8 +52,7 @@ namespace Altinn.AccessManagement.Tests
                 _prp,
                 _delegationMetadataRepositoryMock,
                 _eventQueue,
-                _logger.Object,
-                _resourceRegistryClientMock);
+                _logger.Object);
         }
 
         /// <summary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Removed resource lookup from WriteDelegationPolicyInternal and DeleteAllRulesInPolicy
- In both cases its only used for setting ResourceType on the DelegationChange and used for switching whether it's a App delegation change or ResourceRegistry delegation change that is to be written to the PostgreSQL database.
- Changed this switching to instead just use the ResourceAttributeMatchType

## Related Issue(s)
- #147 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
