### PR TITLE
Fixed cleanup step in a k6 test

### DIFF
--- a/test/K6/src/tests/delegations/inheritancev2.js
+++ b/test/K6/src/tests/delegations/inheritancev2.js
@@ -404,11 +404,10 @@ export function delegationToOrgIsInheritedByECUserViaKeyrole() {
     'Delegation to Org is inherited by ECUser via keyrole - type is 2': (r) => r.json('0.type') === 2,
   });
   addErrorCount(success);
-  
-  // Cleanup
       
   // Cleanup
-  helper.deleteAllRules(altinnToken, performedByUserId, offeredByPartyId, coveredByPartyId, 'partyid', appOwner, appName);
+  policyMatchKeys.coveredBy = 'urn:altinn:partyid';
+  helper.deleteAllRules(altinnToken, user1_userId, org1_partyId, org2_partyId, 'partyid', appOwner, appName);
   res = delegation.getRules(altinnToken, policyMatchKeys, offeredByPartyId, ecUserIdForCoveredBy, resources, null, [coveredByPartyId]);
   success = check(res, {
     'Delegation to Org is inherited by ECUser via keyrole - rules successfully deleted, status is 200': (r) => r.status == 200,


### PR DESCRIPTION
## Description
The test `delegationToOrgIsInheritedByECUserViaKeyrole` does not completely remove all rules in the cleanup step. Updated it so it correctly deletes all rules used in the test.

## Related Issue(s)
- #284 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
