### PR TITLE
Added the use of JsonSerializerOptions to LookupPartyBySSNOrOrgNo

### DIFF
--- a/src/Altinn.AccessManagement/Controllers/LookupController.cs
+++ b/src/Altinn.AccessManagement/Controllers/LookupController.cs
@@ -59,7 +59,15 @@ namespace Altinn.AccessManagement.Controllers
                 }
 
                 Party party = await _register.GetOrganisation(orgNummer);
-                return _mapper.Map<PartyExternal>(party);
+
+                if (party == null)
+                {
+                    return new ObjectResult(ProblemDetailsFactory.CreateValidationProblemDetails(HttpContext, ModelState, 400));
+                }
+                else
+                {
+                    return _mapper.Map<PartyExternal>(party);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Added the use of JsonSerializerOptions to the method LookupPartyBySSNOrOrgNo and made the serializerOptions variable globally available in PartiesClient.cs.

Also changed the response if orgnr in input returns no results.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
