### PR TITLE
Removed doubled API path from ResourceRegistryClient

### DIFF
--- a/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
+++ b/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
@@ -62,7 +62,7 @@ namespace Altinn.AccessManagement.Integration.Clients
 
             try
             {
-                string endpointUrl = $"resourceregistry/api/v1/resource/search";
+                string endpointUrl = $"resource/search";
 
                 HttpResponseMessage response = await _httpClient.GetAsync(endpointUrl);
                 if (response.StatusCode == HttpStatusCode.OK)
@@ -94,7 +94,7 @@ namespace Altinn.AccessManagement.Integration.Clients
             List<ServiceResource> resources = new List<ServiceResource>();
             ResourceSearch resourceSearch = new ResourceSearch();
             resourceSearch.ResourceType = resourceType;
-            string endpointUrl = $"resourceregistry/api/v1/resource/search?ResourceType={(int)resourceType}";
+            string endpointUrl = $"resource/search?ResourceType={(int)resourceType}";
 
             HttpResponseMessage response = await _httpClient.GetAsync(endpointUrl);
             if (response.StatusCode == HttpStatusCode.OK)


### PR DESCRIPTION
Removed doubled API path from ResourceRegistryClient

## Description
After cleanup of configuration values in issue #311 there is now a double API path in config value and in client implementation.
- Removed the api path from the client

## Related Issue(s)
- #322

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
