### PR TITLE
Adding scope authorization for Maskinporten delegations API

### DIFF
--- a/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
+++ b/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
@@ -6,11 +6,6 @@
     public static class AuthzConstants
     {
         /// <summary>
-        /// Policy tag for authorizing designer access
-        /// </summary>
-        public const string POLICY_STUDIO_DESIGNER = "StudioDesignerAccess";
-
-        /// <summary>
         /// Policy tag for authorizing Altinn.Platform.Authorization API access from AltinnII Authorization
         /// </summary>
         public const string ALTINNII_AUTHORIZATION = "AltinnIIAuthorizationAccess";
@@ -29,5 +24,35 @@
         /// Policy tag for writing an maskinporten delegation
         /// </summary>
         public const string POLICY_MASKINPORTEN_DELEGATION_WRITE = "MaskinportenDelegationWrite";
+
+        /// <summary>
+        /// Policy tag for scope authorization on the proxy API from Altinn II for the maskinporten integration API
+        /// </summary>
+        public const string POLICY_MASKINPORTEN_DELEGATIONS_PROXY = "MaskinportenDelegationsProxy";
+
+        /// <summary>
+        /// Scope giving access to delegations for Maskinporten schemes owned by authenticated party 
+        /// </summary>
+        public const string SCOPE_MASKINPORTEN_DELEGATIONS = "altinn:maskinporten/delegations";
+
+        /// <summary>
+        /// Scope giving access to delegations for arbitrary Maskinporten schemes
+        /// </summary>
+        public const string SCOPE_MASKINPORTEN_DELEGATIONS_ADMIN = "altinn:maskinporten/delegations.admin";
+
+        /// <summary>
+        /// Claim for scopes from maskinporten token
+        /// </summary>
+        public const string CLAIM_MASKINPORTEN_SCOPE = "scope";
+
+        /// <summary>
+        /// Claim for full consumer from maskinporten token
+        /// </summary>
+        public const string CLAIM_MASKINPORTEN_CONSUMER = "consumer";
+
+        /// <summary>
+        /// Claim for consumer prefixes from maskinporten token
+        /// </summary>
+        public const string CLAIM_MASKINPORTEN_CONSUMER_PREFIX = "consumer_prefix";
     }
 }

--- a/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
+++ b/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
@@ -58,11 +58,11 @@ namespace Altinn.AccessManagement.Integration.Clients
         /// <inheritdoc/>
         public async Task<List<ServiceResource>> GetResources()
         {
-            List<ServiceResource> resources = null;
+            List<ServiceResource> resources = new();
 
             try
             {
-                string endpointUrl = $"resourceregistry/api/v1/resource/search";
+                string endpointUrl = $"resource/search";
 
                 HttpResponseMessage response = await _httpClient.GetAsync(endpointUrl);
                 if (response.StatusCode == HttpStatusCode.OK)
@@ -94,7 +94,7 @@ namespace Altinn.AccessManagement.Integration.Clients
             List<ServiceResource> resources = new List<ServiceResource>();
             ResourceSearch resourceSearch = new ResourceSearch();
             resourceSearch.ResourceType = resourceType;
-            string endpointUrl = $"resourceregistry/api/v1/resource/search?ResourceType={(int)resourceType}";
+            string endpointUrl = $"resource/search?ResourceType={(int)resourceType}";
 
             HttpResponseMessage response = await _httpClient.GetAsync(endpointUrl);
             if (response.StatusCode == HttpStatusCode.OK)

--- a/src/Altinn.AccessManagement/Controllers/DelegationsController.cs
+++ b/src/Altinn.AccessManagement/Controllers/DelegationsController.cs
@@ -1,13 +1,10 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Net;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Enums;
 using Altinn.AccessManagement.Core.Helpers;
 using Altinn.AccessManagement.Core.Helpers.Extensions;
 using Altinn.AccessManagement.Core.Models;
-using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Services.Interfaces;
 using Altinn.AccessManagement.Filters;
 using Altinn.AccessManagement.Models;
@@ -306,9 +303,19 @@ namespace Altinn.AccessManagement.Controllers
         /// <response code="500">Internal Server Error</response>
         [HttpGet]
         [Route("accessmanagement/api/v1/admin/delegations/maskinportenschema")]
-        [Authorize]
+        [Authorize(Policy = AuthzConstants.POLICY_MASKINPORTEN_DELEGATIONS_PROXY)]
         public async Task<ActionResult<List<MPDelegationExternal>>> GetMaskinportenSchemaDelegations([FromQuery] string? supplierOrg, string? consumerOrg, string scope)
         {
+            if (string.IsNullOrEmpty(scope))
+            {
+                return BadRequest("Either the parameter scope has no value or the provided value is invalid");
+            }
+
+            if (!MaskinportenSchemaAuthorizer.IsAuthorizedDelegationLookupAccess(scope, HttpContext.User))
+            {
+                return StatusCode(403, $"Not authorized for lookup of delegations for the scope: {scope}");
+            }
+
             if (!string.IsNullOrEmpty(supplierOrg) && !IdentifierUtil.IsValidOrganizationNumber(supplierOrg))
             {
                 return BadRequest("Supplierorg is not an valid organization number");
@@ -317,12 +324,7 @@ namespace Altinn.AccessManagement.Controllers
             if (!string.IsNullOrEmpty(consumerOrg) && !IdentifierUtil.IsValidOrganizationNumber(consumerOrg))
             {
                 return BadRequest("Consumerorg is not an valid organization number");
-            }
-
-            if (string.IsNullOrEmpty(scope))
-            {
-                return BadRequest("Either the parameter scope has no value or the provided value is invalid");
-            }
+            }            
 
             try
             {

--- a/src/Altinn.AccessManagement/Controllers/ResourceController.cs
+++ b/src/Altinn.AccessManagement/Controllers/ResourceController.cs
@@ -45,7 +45,7 @@ namespace Altinn.AccessManagement.Controllers
         /// </summary>
         /// <param name="resources">List of new Resources to add or update</param>
         /// <returns></returns>
-        ////[Authorize(Policy = "PlatformAccess")]
+        [Authorize(Policy = "PlatformAccess")]
         [HttpPost]
         [HttpPut]
         [Route("accessmanagement/api/v1/internal/resources")]

--- a/src/Altinn.AccessManagement/Controllers/ResourceController.cs
+++ b/src/Altinn.AccessManagement/Controllers/ResourceController.cs
@@ -45,7 +45,7 @@ namespace Altinn.AccessManagement.Controllers
         /// </summary>
         /// <param name="resources">List of new Resources to add or update</param>
         /// <returns></returns>
-        [Authorize(Policy = "PlatformAccess")]
+        ////[Authorize(Policy = "PlatformAccess")]
         [HttpPost]
         [HttpPut]
         [Route("accessmanagement/api/v1/internal/resources")]

--- a/src/Altinn.AccessManagement/Program.cs
+++ b/src/Altinn.AccessManagement/Program.cs
@@ -24,7 +24,6 @@ using Altinn.Common.PEP.Clients;
 using Altinn.Common.PEP.Implementation;
 using Altinn.Common.PEP.Interfaces;
 using AltinnCore.Authentication.JwtCookie;
-
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
@@ -273,12 +272,12 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
 
     services.AddAuthorization(options =>
     {
-        options.AddPolicy(AuthzConstants.POLICY_STUDIO_DESIGNER, policy => policy.Requirements.Add(new ClaimAccessRequirement("urn:altinn:app", "studio.designer")));
+        options.AddPolicy("PlatformAccess", policy => policy.Requirements.Add(new AccessTokenRequirement()));
         options.AddPolicy(AuthzConstants.ALTINNII_AUTHORIZATION, policy => policy.Requirements.Add(new ClaimAccessRequirement("urn:altinn:app", "sbl.authorization")));
         options.AddPolicy(AuthzConstants.INTERNAL_AUTHORIZATION, policy => policy.Requirements.Add(new ClaimAccessRequirement("urn:altinn:app", "internal.authorization")));
         options.AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_READ, policy => policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_maskinporten_scope_delegation")));
         options.AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATION_WRITE, policy => policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_maskinporten_scope_delegation")));
-        options.AddPolicy("PlatformAccess", policy => policy.Requirements.Add(new AccessTokenRequirement()));
+        options.AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATIONS_PROXY, policy => policy.Requirements.Add(new ScopeAccessRequirement(new string[] { "altinn:maskinporten/delegations", "altinn:maskinporten/delegations.admin" })));
     });
     
     services.AddTransient<IAuthorizationHandler, ClaimAccessHandler>(); 

--- a/src/Altinn.AccessManagement/Utilities/MaskinportenSchemaAuthorizer.cs
+++ b/src/Altinn.AccessManagement/Utilities/MaskinportenSchemaAuthorizer.cs
@@ -1,0 +1,51 @@
+﻿using System.Security.Claims;
+using Altinn.AccessManagement.Core.Constants;
+
+namespace Altinn.AccessManagement.Utilities
+{
+    /// <summary>
+    /// Authorization helper for custom authorization for maskinporten schema API operations
+    /// </summary>
+    public static class MaskinportenSchemaAuthorizer
+    {
+        /// <summary>
+        /// Authorization of whether the provided claims is authorized for lookup of delegations of the given scope
+        /// </summary>
+        /// <param name="scope">The scope to authorize for delegation lookup</param>
+        /// <param name="claims">The claims principal of the authenticated organization</param>
+        /// <returns>bool</returns>
+        public static bool IsAuthorizedDelegationLookupAccess(string scope, ClaimsPrincipal claims)
+        {
+            if (HasDelegationsAdminScope(claims))
+            {
+                return true;
+            }
+
+            return HasAuthorizedScopePrefixClaim(new[] { scope }, claims);
+        }
+
+        private static bool HasDelegationsAdminScope(ClaimsPrincipal claims)
+        {
+            return HasScope(claims, AuthzConstants.SCOPE_MASKINPORTEN_DELEGATIONS_ADMIN);
+        }
+
+        private static bool HasScope(ClaimsPrincipal claims, string scope)
+        {
+            Claim c = claims.Claims.FirstOrDefault(x => x.Type == AuthzConstants.CLAIM_MASKINPORTEN_SCOPE);
+            if (c == null)
+            {
+                return false;
+            }
+
+            string[] scopes = c.Value.Split(' ');
+
+            return scopes.Contains(scope);
+        }
+
+        private static bool HasAuthorizedScopePrefixClaim(IEnumerable<string> scopesToAuthorize, ClaimsPrincipal claims)
+        {
+            List<string> prefixes = claims.Claims.Where(x => x.Type == AuthzConstants.CLAIM_MASKINPORTEN_CONSUMER_PREFIX).Select(v => v.Value).ToList();
+            return scopesToAuthorize.All(scopes => prefixes.Any(prefix => scopes.StartsWith(prefix + ':')));
+        }
+    }
+}

--- a/src/Altinn.AccessManagement/appsettings.json
+++ b/src/Altinn.AccessManagement/appsettings.json
@@ -56,14 +56,6 @@
     "altinn": {
       "Issuer": "http://localhost:5101/authentication/api/v1/openid/",
       "WellKnownConfigEndpoint": "http://localhost:5101/authentication/api/v1/openid/.well-known/openid-configuration"
-    },
-    "maskinporten-ver2": {
-      "Issuer": "https://ver2.maskinporten.no/",
-      "WellKnownConfigEndpoint": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server"
-    },
-    "maskinporten-test": {
-      "Issuer": "https://test.maskinporten.no/",
-      "WellKnownConfigEndpoint": "https://test.maskinporten.no/.well-known/oauth-authorization-server"
     }
   }
 }

--- a/src/Altinn.AccessManagement/appsettings.json
+++ b/src/Altinn.AccessManagement/appsettings.json
@@ -16,7 +16,6 @@
     "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",
     "ApiResourceRegistryEndpoint": "http://localhost:5101/resourceregistry/api/v1/",
     "JwtCookieName": "AltinnStudioRuntime",
-    "OpenIdWellKnownEndpoint": "http://localhost:5101/authentication/api/v1/openid/",
     "SubscriptionKeyHeaderName": "Ocp-Apim-Subscription-Key"
   },
   "PostgreSQLSettings": {
@@ -52,5 +51,19 @@
     "Hostname": "localhost",
     "DisableCsrfCheck": false,
     "FrontendBaseUrl": "https://amcdntest.z16.web.core.windows.net/"
+  },
+  "OidcProviders": {
+    "altinn": {
+      "Issuer": "http://localhost:5101/authentication/api/v1/openid/",
+      "WellKnownConfigEndpoint": "http://localhost:5101/authentication/api/v1/openid/.well-known/openid-configuration"
+    },
+    "maskinporten-ver2": {
+      "Issuer": "https://ver2.maskinporten.no/",
+      "WellKnownConfigEndpoint": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server"
+    },
+    "maskinporten-test": {
+      "Issuer": "https://test.maskinporten.no/",
+      "WellKnownConfigEndpoint": "https://test.maskinporten.no/.well-known/oauth-authorization-server"
+    }
   }
 }


### PR DESCRIPTION
## Description
- Setup scope authorization policy requiring either scope "altinn:maskinporten/delegations" or "altinn:maskinporten/delegations.admin" for access to operation
- Implemented custom authorization on the lookup scope, for whether authenticated org has the admin scope or owns the scope prefix (defined in consumer_prefix claim from maskinporten token)
- Switched config for well-known endpoints in order to support both ver2 and test environments/issuers from maskinporten (Separate PR made for environment deploy variables will be merged as well)
- Fixes for some minor null-reference errors found during manual integration testing with SBL proxy API

## Related Issue(s)
- #299

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
