### PR TITLE
Fix backend PartyId lookup to use endpoint without user authorization

### DIFF
--- a/src/Altinn.AccessManagement.Core/Services/DelegationsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/DelegationsService.cs
@@ -216,7 +216,8 @@ namespace Altinn.AccessManagement.Core.Services
             }
             else if (DelegationHelper.TryGetPartyIdFromAttributeMatch(delegation.From, out int fromPartyId))
             {
-                fromParty = await _contextRetrievalService.GetPartyAsync(fromPartyId);
+                List<Party> fromPartyLookup = await _contextRetrievalService.GetPartiesAsync(fromPartyId.SingleToList());
+                fromParty = fromPartyLookup.FirstOrDefault();
             }
 
             if (fromParty == null || fromParty.PartyTypeName != PartyType.Organisation)
@@ -233,7 +234,8 @@ namespace Altinn.AccessManagement.Core.Services
             }
             else if (DelegationHelper.TryGetPartyIdFromAttributeMatch(delegation.To, out int toPartyId))
             {
-                toParty = await _contextRetrievalService.GetPartyAsync(toPartyId);
+                List<Party> toPartyLookup = await _contextRetrievalService.GetPartiesAsync(toPartyId.SingleToList());
+                toParty = toPartyLookup.FirstOrDefault();
             }
 
             if (toParty == null || toParty.PartyTypeName != PartyType.Organisation)

--- a/test/Altinn.AccessManagement.Tests/Mocks/PartiesClientMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/PartiesClientMock.cs
@@ -42,7 +42,11 @@ namespace Altinn.AccessManagement.Tests.Mocks
 
                 foreach (int partyId in parties.Distinct())
                 {
-                    filteredList.Add(partyList.Find(p => p.PartyId == partyId));
+                    Party party = partyList.Find(p => p.PartyId == partyId);
+                    if (party != null)
+                    {
+                        filteredList.Add(party);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description
Register endpoint for lookup of Party based on PartyId requires user authorization for the reportee (have the party in their reporteelist).

Backend lookups should not be limited by user authorization. In this case looking up the party which is to receive a delegation.

## Related Issue(s)
- #334

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
