### PR TITLE
Removed "showTestData()" that prints a lot of debug info

### DIFF
--- a/test/K6/src/tests/delegations/inheritancev2.js
+++ b/test/K6/src/tests/delegations/inheritancev2.js
@@ -140,7 +140,6 @@ export default function (data) {
   CleanupBeforeTests();
 
   //tests
-  showTestData();
   directDelegationFromOrgToUser();
   directDelegationFromOrgToOrg();
   directDelegationFromMainUnitToUser();


### PR DESCRIPTION
## Description
pipeline logs does not like console.log(), and counts them as warnings. Removed "showTestData()" that prints a lot of debug info

## Related Issue(s)
- #302 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
