### PR TITLE
Fix for bug in lookup/reportee/{partyId}

### DIFF
--- a/src/Altinn.AccessManagement.Core/Models/Delegation.cs
+++ b/src/Altinn.AccessManagement.Core/Models/Delegation.cs
@@ -90,6 +90,5 @@ namespace Altinn.AccessManagement.Core.Models
         /// Description explaining the rights a recipient will receive if given access to the resource
         /// </summary>
         public Dictionary<string, string> RightDescription { get; set; }
-
     }
 }

--- a/src/Altinn.AccessManagement.Core/Services/DelegationsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/DelegationsService.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using Altinn.AccessManagement.Core.Constants;
+﻿using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Enums;
 using Altinn.AccessManagement.Core.Helpers;
 using Altinn.AccessManagement.Core.Helpers.Extensions;

--- a/src/Altinn.AccessManagement.Integration/Clients/PartiesClient.cs
+++ b/src/Altinn.AccessManagement.Integration/Clients/PartiesClient.cs
@@ -68,90 +68,77 @@ namespace Altinn.AccessManagement.Integration.Clients
                 var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "access-management");
 
                 HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, accessToken);
+                string responseContent = await response.Content.ReadAsStringAsync();
 
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    string responseContent = await response.Content.ReadAsStringAsync();
-                    Party partyInfo = JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
-                    return partyInfo;
+                    return JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
                 }
-                else
-                {
-                    _logger.LogError("Getting party information from bridge failed with {StatusCode}", response.StatusCode);
-                }
+                
+                _logger.LogError("AccessManagement // PartiesClient // GetPartyAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+                return null;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "AccessManagement // PartiesClient // GetPartyAsync // Exception");
                 throw;
             }
-
-            return null;
         }
 
         /// <inheritdoc/>
-        public async Task<int> GetPartyId(string id)
+        public async Task<int> GetPartyId(string ssnOrOrgNo)
         {
-            int partyId = 0;
             try
             {
                 string endpointUrl = $"register/api/parties/lookup";
-                StringContent requestBody = new StringContent(JsonSerializer.Serialize(id), Encoding.UTF8, "application/json");
+                StringContent requestBody = new StringContent(JsonSerializer.Serialize(ssnOrOrgNo), Encoding.UTF8, "application/json");
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "access-management");
-                HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody, accessToken);
 
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody, accessToken);
+                string responseContent = await response.Content.ReadAsStringAsync();
+
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    string responseContent = response.Content.ReadAsStringAsync().Result;
-                    partyId = JsonSerializer.Deserialize<int>(responseContent, _serializerOptions);
-                    return partyId;
+                    return JsonSerializer.Deserialize<int>(responseContent, _serializerOptions);
                 }
-                else
-                {
-                    _logger.LogError("Getting party information from bridge failed with {StatusCode}", response.StatusCode);
-                }
+
+                _logger.LogError("AccessManagement // PartiesClient // GetPartyId // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+                return 0;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "AccessManagement // PartiesClient // GetPartyAsync // Exception");
+                _logger.LogError(ex, "AccessManagement // PartiesClient // GetPartyId // Exception");
                 throw;
             }
-
-            return partyId;
         }
 
         /// <inheritdoc/>
         public async Task<List<Party>> GetPartiesAsync(List<int> parties)
         {
-            List<Party> filteredList = new List<Party>();
-
             try
             {
                 string endpointUrl = $"parties/partylist/";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "access-management");
                 StringContent requestBody = new StringContent(JsonSerializer.Serialize(parties), Encoding.UTF8, "application/json");
+                
                 HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody, accessToken);
+                string responseContent = await response.Content.ReadAsStringAsync();
 
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    string responseContent = await response.Content.ReadAsStringAsync();
-                    List<Party> partiesInfo = JsonSerializer.Deserialize<List<Party>>(responseContent, _serializerOptions);
-                    return partiesInfo;
+                    return JsonSerializer.Deserialize<List<Party>>(responseContent, _serializerOptions);
                 }
-                else
-                {
-                    _logger.LogError("Getting parties information from bridge failed with {StatusCode}", response.StatusCode);
-                }
+
+                _logger.LogError("AccessManagement // PartiesClient // GetPartiesAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+                return new();
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "AccessManagement // PartiesClient // GetPartiesAsync // Exception");
                 throw;
             }
-
-            return filteredList;
         }
 
         /// <inheritdoc/>
@@ -164,25 +151,21 @@ namespace Altinn.AccessManagement.Integration.Clients
                 var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "access-management");
 
                 HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, accessToken);
+                string responseContent = await response.Content.ReadAsStringAsync();
 
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    string responseContent = await response.Content.ReadAsStringAsync();
-                    List<Party> partiesInfo = JsonSerializer.Deserialize<List<Party>>(responseContent, _serializerOptions);
-                    return partiesInfo;
+                    return JsonSerializer.Deserialize<List<Party>>(responseContent, _serializerOptions);
                 }
-                else
-                {
-                    _logger.LogError("Getting parties information from authorization failed with {StatusCode}", response.StatusCode);
-                }
+
+                _logger.LogError("AccessManagement // PartiesClient // GetPartiesForUserAsync // Unexpected HttpStatusCode: {StatusCode}\n {responseContent}", response.StatusCode, responseContent);
+                return new();
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "AccessManagement // PartiesClient // GetPartiesForUserAsync // Exception");
                 throw;
             }
-
-            return null;
         }
 
         /// <inheritdoc/>
@@ -236,7 +219,7 @@ namespace Altinn.AccessManagement.Integration.Clients
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "AccessManagement // PartiesClient // partyparents // Failed // Unexpected Exception");
+                _logger.LogError(ex, "AccessManagement // PartiesClient // GetMainUnits // Failed // Unexpected Exception");
                 throw;
             }
         }
@@ -244,33 +227,29 @@ namespace Altinn.AccessManagement.Integration.Clients
         /// <inheritdoc/>
         public async Task<Party> LookupPartyBySSNOrOrgNo(PartyLookup partyLookup)
         {
-            Party party = null;
             try
             {
                 string endpointUrl = $"parties/lookup";
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _platformSettings.JwtCookieName);
                 var accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "access-management");
                 StringContent requestBody = new StringContent(JsonSerializer.Serialize(partyLookup, _serializerOptions), Encoding.UTF8, "application/json");
-                HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody, accessToken);
 
-                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                HttpResponseMessage response = await _client.PostAsync(token, endpointUrl, requestBody, accessToken);
+                string responseContent = await response.Content.ReadAsStringAsync();
+
+                if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    string responseContent = await response.Content.ReadAsStringAsync();
-                    party = JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
-                    return party;
+                    return JsonSerializer.Deserialize<Party>(responseContent, _serializerOptions);
                 }
-                else
-                {
-                    _logger.LogError("Getting party information from register failed with {StatusCode}", response.StatusCode);
-                }
+
+                _logger.LogError("AccessManagement // PartiesClient // LookupPartyBySSNOrOrgNo // Unexpected HttpStatusCode: {StatusCode}\n {responseBody}", response.StatusCode, responseContent);
+                return null;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "AccessManagement // PartiesClient // LookupPartyBySSNOrOrgNo // Exception");
                 throw;
             }
-
-            return party;
         }
     }
 }

--- a/test/Altinn.AccessManagement.Tests/Controllers/LookupControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/LookupControllerTest.cs
@@ -29,10 +29,7 @@ namespace Altinn.AccessManagement.Tests.Controllers
         private readonly CustomWebApplicationFactory<LookupController> _factory;
         private readonly HttpClient _client;
 
-        private readonly JsonSerializerOptions options = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-        };
+        private readonly JsonSerializerOptions serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
 
         /// <summary>
         /// Constructor setting up factory, test client and dependencies
@@ -61,12 +58,8 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/lookup/org/{810418192}");
             string responseContent = await response.Content.ReadAsStringAsync();
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-            };
             
-            PartyExternal actualOrganisation = JsonSerializer.Deserialize<PartyExternal>(responseContent, options);
+            PartyExternal actualOrganisation = JsonSerializer.Deserialize<PartyExternal>(responseContent, serializerOptions);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -127,16 +120,11 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/lookup/reportee/{expectedParty.PartyId}");
             string responseContent = await response.Content.ReadAsStringAsync();
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-            };
-
-            PartyExternal actualParty = JsonSerializer.Deserialize<PartyExternal>(responseContent, options);
-            actualParty.SSN = IdentifierUtil.MaskSSN(actualParty.SSN);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            PartyExternal actualParty = JsonSerializer.Deserialize<PartyExternal>(responseContent, serializerOptions);
             AssertionUtil.AssertPartyEqual(expectedParty, actualParty);
         }
 
@@ -157,15 +145,11 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/lookup/reportee/{expectedParty.PartyId}");
             string responseContent = await response.Content.ReadAsStringAsync();
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-            };
-
-            PartyExternal actualParty = JsonSerializer.Deserialize<PartyExternal>(responseContent, options);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            PartyExternal actualParty = JsonSerializer.Deserialize<PartyExternal>(responseContent, serializerOptions);
             AssertionUtil.AssertPartyEqual(expectedParty, actualParty);
         }
 
@@ -187,15 +171,11 @@ namespace Altinn.AccessManagement.Tests.Controllers
             // Act
             HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/lookup/reportee/{expectedParty.PartyId}");
             string responseContent = await response.Content.ReadAsStringAsync();
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-            };
-
-            PartyExternal actualParty = JsonSerializer.Deserialize<PartyExternal>(responseContent, options);
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            PartyExternal actualParty = JsonSerializer.Deserialize<PartyExternal>(responseContent, serializerOptions);
             AssertionUtil.AssertPartyEqual(expectedParty, actualParty);
         }
 

--- a/test/Altinn.AccessManagement.Tests/Data/Parties/parties.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Parties/parties.json
@@ -1,6 +1,63 @@
 [
   {
     "PartyTypeName": 2,
+    "SSN": "null",
+    "OrgNumber": "910493353",
+    "Person": null,
+    "Organization": {
+      "OrgNumber": "910493353",
+      "Name": "LEPSØY OG TONSTAD",
+      "UnitType": "AS",
+      "TelephoneNumber": null,
+      "MobileNumber": null,
+      "FaxNumber": null,
+      "EMailAddress": "test@test.test",
+      "InternetAddress": null,
+      "MailingAddress": null,
+      "MailingPostalCode": null,
+      "MailingPostalCity": null,
+      "BusinessAddress": null,
+      "BusinessPostalCode": null,
+      "BusinessPostalCity": null
+    },
+    "PartyId": 50006078,
+    "UnitType": "AS",
+    "Name": "LEPSØY OG TONSTAD",
+    "IsDeleted": false,
+    "OnlyHierarchyElementWithNoAccess": false,
+    "ChildParties": [
+      {
+        "PartyTypeName": 2,
+        "SSN": "null",
+        "OrgNumber": "910422154",
+        "Person": null,
+        "Organization": {
+          "OrgNumber": "910422154",
+          "Name": "ROGNE OG HERØY",
+          "UnitType": "AS",
+          "TelephoneNumber": null,
+          "MobileNumber": null,
+          "FaxNumber": null,
+          "EMailAddress": "test@test.test",
+          "InternetAddress": null,
+          "MailingAddress": null,
+          "MailingPostalCode": null,
+          "MailingPostalCity": null,
+          "BusinessAddress": null,
+          "BusinessPostalCode": null,
+          "BusinessPostalCity": null
+        },
+        "PartyId": 50004646,
+        "UnitType": "AS",
+        "Name": "ROGNE OG HERØY",
+        "IsDeleted": false,
+        "OnlyHierarchyElementWithNoAccess": false,
+        "ChildParties": null
+      }
+    ]
+  },
+  {
+    "PartyTypeName": 2,
     "SSN": "",
     "OrgNumber": "10008387",
     "Person": null,
@@ -250,63 +307,6 @@
     "IsDeleted": false,
     "OnlyHierarchyElementWithNoAccess": false,
     "ChildParties": null
-  },
-  {
-    "PartyTypeName": 2,
-    "SSN": "null",
-    "OrgNumber": "910493353",
-    "Person": null,
-    "Organization": {
-      "OrgNumber": "910493353",
-      "Name": "LEPSØY OG TONSTAD",
-      "UnitType": "AS",
-      "TelephoneNumber": null,
-      "MobileNumber": null,
-      "FaxNumber": null,
-      "EMailAddress": "test@test.test",
-      "InternetAddress": null,
-      "MailingAddress": null,
-      "MailingPostalCode": null,
-      "MailingPostalCity": null,
-      "BusinessAddress": null,
-      "BusinessPostalCode": null,
-      "BusinessPostalCity": null
-    },
-    "PartyId": 50006078,
-    "UnitType": "AS",
-    "Name": "LEPSØY OG TONSTAD",
-    "IsDeleted": false,
-    "OnlyHierarchyElementWithNoAccess": false,
-    "ChildParties": [
-      {
-        "PartyTypeName": 2,
-        "SSN": "null",
-        "OrgNumber": "910422154",
-        "Person": null,
-        "Organization": {
-          "OrgNumber": "910422154",
-          "Name": "ROGNE OG HERØY",
-          "UnitType": "AS",
-          "TelephoneNumber": null,
-          "MobileNumber": null,
-          "FaxNumber": null,
-          "EMailAddress": "test@test.test",
-          "InternetAddress": null,
-          "MailingAddress": null,
-          "MailingPostalCode": null,
-          "MailingPostalCity": null,
-          "BusinessAddress": null,
-          "BusinessPostalCode": null,
-          "BusinessPostalCity": null
-        },
-        "PartyId": 50004646,
-        "UnitType": "AS",
-        "Name": "ROGNE OG HERØY",
-        "IsDeleted": false,
-        "OnlyHierarchyElementWithNoAccess": false,
-        "ChildParties": null
-      }
-    ]
   },
   {
     "PartyTypeName": 2,

--- a/test/Altinn.AccessManagement.Tests/Mocks/MessageHandlerMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/MessageHandlerMock.cs
@@ -17,7 +17,7 @@ public class MessageHandlerMock : DelegatingHandler
     /// Initializes a new instance of the <see cref="MessageHandlerMock"/> class.
     /// </summary>
     /// <param name="expectedResponseStatus">Expected HttpStatusCode</param>
-    /// <param name="jsonContent">Expected response content</param>
+    /// <param name="httpContent">Expected response content</param>
     public MessageHandlerMock(HttpStatusCode expectedResponseStatus, HttpContent httpContent)
     {
         _expectedResponseStatus = expectedResponseStatus;

--- a/test/Altinn.AccessManagement.Tests/Mocks/PartiesClientMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/PartiesClientMock.cs
@@ -172,7 +172,6 @@ namespace Altinn.AccessManagement.Tests.Mocks
         public Task<List<Party>> GetPartiesForUserAsync(int userId)
         {
             List<Party> partyList = new List<Party>();
-            Party partyToReturn = null;
 
             string path = GetPartiesPaths();
             if (Directory.Exists(path))
@@ -187,32 +186,9 @@ namespace Altinn.AccessManagement.Tests.Mocks
                         partyList = JsonSerializer.Deserialize<List<Party>>(content);
                     }
                 }
-
-                foreach (Party party in partyList)
-                {
-                    if (party != null && party.PartyId == userId)
-                    {
-                        partyToReturn = party;
-                    }
-                    else if (party != null && party.ChildParties != null && party.ChildParties.Count > 0)
-                    {
-                        foreach (Party childParty in party.ChildParties)
-                        {
-                            if (childParty.PartyId == userId)
-                            {
-                                partyToReturn = party;
-                            }
-                        }
-                    }
-                }
             }
 
-            List<Party> returnedPartyList = new List<Party>
-            {
-                partyToReturn
-            };
-
-            return Task.FromResult(returnedPartyList);
+            return Task.FromResult(partyList);
         }
 
         private static string GetPartiesPaths()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ContextRetrievalService.GetPartyForUser had a bug where it would return result after the first reportee with child reportees, whether or not the reportee was found among the child reportees.

Fixed some minor compile warnings and error logging in PartiesClient

## Related Issue(s)
- #371

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] No environment config in appsettings.json, or separate environment variables PR made
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
