### PR TITLE
add non-happyflow K6 tests for maskinportenschema

### DIFF
--- a/test/K6/src/tests/maskinporten/maskinporten.js
+++ b/test/K6/src/tests/maskinporten/maskinporten.js
@@ -12,13 +12,7 @@ import { check, sleep, fail } from 'k6';
 import { addErrorCount, stopIterationOnFail } from '../../errorcounter.js';
 import { generateToken } from '../../api/altinn-testtools/token-generator.js';
 import { generateJUnitXML, reportPath } from '../../report.js';
-import * as delegation from '../../api/platform/authorization/delegations.js';
 import * as maskinporten from '../../api/platform/authorization/maskinporten.js';
-import * as authorization from '../../api/platform/authorization/authorization.js';
-import * as setUpData from '../../setup.js';
-import * as helper from '../../Helpers/TestdataHelper.js';
-
-let pdpInputJson = open('../../data/pdpinput.json');
 
 const environment = __ENV.env.toLowerCase();
 const tokenGeneratorUserName = __ENV.tokengenuser;
@@ -121,11 +115,15 @@ export default function (data) {
   //tests
   postMaskinportenSchemaToOrgNumberTest();
   postMaskinportenSchemaToPartyIdTest();
+  getMaskinPortenSchemaOfferedInvalidPartyId();
+  getMaskinPortenSchemaReceivedInvalidPartyId();
   postMaskinportenSchemaNotReadyTest();
   getMaskinPortenSchemaOfferedTest();
   getMaskinPortenSchemaReceivedTest();
   revokeOfferedMaskinPortenSchema();
   revokeReceivedMaskinPortenSchema();
+  revokeOfferedMaskinPortenSchemaUsingPartyId();
+  revokeReceivedMaskinPortenSchemaUsingPartyId();
   revokeNonExistentOfferedMaskinPortenSchema();
   revokeNonExistentReceivedMaskinPortenSchema();
 
@@ -136,6 +134,7 @@ export function getMaskinPortenSchemaOfferedTest() {
   // Arrange
   const offeredByToken = user1_personalToken;
   const offeredByPartyId = org1_partyid;
+  const appid = 'ttd-am-k6-nuf';
 
   // Act
   var res = maskinporten.getMaskinportenSchemaOffered(offeredByToken, offeredByPartyId);
@@ -148,9 +147,25 @@ export function getMaskinPortenSchemaOfferedTest() {
     'get offered MaskinPortenSchemas - coveredByPartyId is ${coveredByPartyId}': (r) => r.json('0.coveredByPartyId') == org2_partyid,
     'get offered MaskinPortenSchemas - performedByUserId is ${performedByUserId}': (r) => r.json('0.performedByUserId') == user1_userid,
     'get offered MaskinPortenSchemas - coveredByOrganizationNumber is ${coveredByOrganizationNumber}': (r) => r.json('0.coveredByOrganizationNumber') == org2_number,
-    'get offered MaskinPortenSchemas - resourceId is appid-544': (r) => r.json('0.resourceId') == 'appid-544',
-    'get offered MaskinPortenSchemas - resourceTitle is Automation Regression': (r) => r.json('0.resourceTitle.en') == 'Automation Regression',
+    'get offered MaskinPortenSchemas - resourceId is ttd-am-k6-nuf': (r) => r.json('0.resourceId') == appid,
+    'get offered MaskinPortenSchemas - resourceTitle is Maskinporten Schema - AM - K6 - NUF': (r) => r.json('0.resourceTitle.en') == 'Maskinporten Schema - AM - K6 - NUF',
     'get offered MaskinPortenSchemas - resourceType is MaskinportenSchema': (r) => r.json('0.resourceType') == 'MaskinportenSchema',
+  });
+  addErrorCount(success);
+}
+
+/** Check that you can't get offered schemas using the wrong partyid */
+export function getMaskinPortenSchemaOfferedInvalidPartyId() {
+  // Arrange
+  const offeredByToken = user1_personalToken;
+  const wrongOfferedByPartyId = org2_partyid;
+
+  // Act
+  var res = maskinporten.getMaskinportenSchemaOffered(offeredByToken, wrongOfferedByPartyId);
+
+  // Assert
+  var success = check(res, {
+    'get offered MaskinPortenSchemas with invalid partyid- status is 403 forbidden': (r) => r.status === 403,
   });
   addErrorCount(success);
 }
@@ -158,24 +173,41 @@ export function getMaskinPortenSchemaOfferedTest() {
 /** Check that list of received maschinportenschemas is correct */
 export function getMaskinPortenSchemaReceivedTest() {
   // Arrange
-  const offeredByToken = user1_personalToken;
-  const offeredByPartyId = org1_partyid;
+  const toToken = user2_personalToken;
+  const toPartyId = org2_partyid;
+  const appid = 'ttd-am-k6-nuf';
 
   // Act
-  var res = maskinporten.getMaskinportenSchemaReceived(offeredByToken, offeredByPartyId);
+  var res = maskinporten.getMaskinportenSchemaReceived(toToken, toPartyId);
   
   // Assert
   var success = check(res, {
     'get Received MaskinPortenSchemas - status is 200': (r) => r.status === 200,
-    'get Received MaskinPortenSchemas - offeredByName is LARKOLLEN OG FAUSKE': (r) => r.json('0.offeredByName') === 'LARKOLLEN OG FAUSKE',
-    'get Received MaskinPortenSchemas - offeredByPartyId is ${offeredByPartyId}': (r) => r.json('0.offeredByPartyId') == org2_partyid,
-    'get Received MaskinPortenSchemas - coveredByPartyId is ${coveredByPartyId}': (r) => r.json('0.coveredByPartyId') == org1_partyid,
-    'get Received MaskinPortenSchemas - performedByUserId is ${performedByUserId}': (r) => r.json('0.performedByUserId') == user2_userid,
-    'get Received MaskinPortenSchemas - offeredByOrganizationNumber is ${offeredByOrganizationNumber}': (r) => r.json('0.offeredByOrganizationNumber') == org2_number,
-    'get Received MaskinPortenSchemas - resourceId is appid-544': (r) => r.json('0.resourceId') == 'appid-544',
-    'get Received MaskinPortenSchemas - resourceTitle is Automation Regression': (r) => r.json('0.resourceTitle.en') == 'Automation Regression',
+    'get Received MaskinPortenSchemas - offeredByName is LARKOLLEN OG FAUSKE': (r) => r.json('0.offeredByName') === 'ALDRA OG FORTUN',
+    'get Received MaskinPortenSchemas - offeredByPartyId is ${offeredByPartyId}': (r) => r.json('0.offeredByPartyId') == org1_partyid,
+    'get Received MaskinPortenSchemas - coveredByPartyId is ${coveredByPartyId}': (r) => r.json('0.coveredByPartyId') == org2_partyid,
+    'get Received MaskinPortenSchemas - performedByUserId is ${performedByUserId}': (r) => r.json('0.performedByUserId') == user1_userid,
+    'get Received MaskinPortenSchemas - offeredByOrganizationNumber is ${offeredByOrganizationNumber}': (r) => r.json('0.offeredByOrganizationNumber') == org1_number,
+    'get Received MaskinPortenSchemas - resourceId is ttd-am-k6-nuf': (r) => r.json('0.resourceId') == appid,
+    'get Received MaskinPortenSchemas - resourceTitle is Maskinporten Schema - AM - K6 - NUF': (r) => r.json('0.resourceTitle.en') == 'Maskinporten Schema - AM - K6 - NUF',
     'get Received MaskinPortenSchemas - resourceType is MaskinportenSchema': (r) => r.json('0.resourceType') == 'MaskinportenSchema',
     
+  });
+  addErrorCount(success);
+}
+
+/** Check that you can't get received schemas using the wrong partyid */
+export function getMaskinPortenSchemaReceivedInvalidPartyId() {
+  // Arrange
+  const toToken = user1_personalToken;
+  const wrongToPartyId = org2_partyid;
+
+  // Act
+  var res = maskinporten.getMaskinportenSchemaOffered(toToken, wrongToPartyId);
+
+  // Assert
+  var success = check(res, {
+    'get received MaskinPortenSchemas with invalid partyid- status is 403 forbidden': (r) => r.status === 403,
   });
   addErrorCount(success);
 }
@@ -186,20 +218,20 @@ export function postMaskinportenSchemaToPartyIdTest() {
   const offeredByToken = user1_personalToken;
   const offeredByPartyId = org1_partyid;
   const toPartyId = org2_partyid;
-  const appid = 'appid-544';
+  const appid = 'ttd-am-k6';
   
   // Act
-  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, toPartyId, appid);
+  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:partyid', toPartyId);
 
   // Assert
   var success = check(res, {
     'post MaskinportenSchema To PartyId - status is 201': (r) => r.status === 201,
-    'post MaskinportenSchema To PartyId - to id is organizationnumber': (r) => r.json('to.0.id') === 'urn:altinn:partyid',
+    'post MaskinportenSchema To PartyId - to id is partyid': (r) => r.json('to.0.id') === 'urn:altinn:partyid',
     'post MaskinportenSchema To PartyId - organization number matches': (r) => r.json('to.0.value') === toPartyId,
-    'post MaskinportenSchema To PartyId - resource type is urn:altinn:resourceregistry': (r) => r.json('rightDelegationResults.0.resource.0.id') === 'urn:altinn:resourceregistry',
+    'post MaskinportenSchema To PartyId - resource type is urn:altinn:resource': (r) => r.json('rightDelegationResults.0.resource.0.id') === 'urn:altinn:resource',
     'post MaskinportenSchema To PartyId - appid matches': (r) => r.json('rightDelegationResults.0.resource.0.value') === appid,
     'post MaskinportenSchema To PartyId - action type is action-id': (r) => r.json('rightDelegationResults.0.action.id') === 'urn:oasis:names:tc:xacml:1.0:action:action-id',
-    'post MaskinportenSchema To PartyId - action value is scopeaccess': (r) => r.json('rightDelegationResults.0.action.value') === 'scopeaccess',
+    'post MaskinportenSchema To PartyId - action value is ScopeAccess': (r) => r.json('rightDelegationResults.0.action.value') === 'ScopeAccess',
   });
 
   addErrorCount(success);
@@ -211,20 +243,20 @@ export function postMaskinportenSchemaToOrgNumberTest() {
   const offeredByToken = user1_personalToken;
   const offeredByPartyId = org1_partyid;
   const toOrgNumber = org2_number;
-  const appid = 'appid-544';
+  const appid = 'ttd-am-k6';
   
   // Act
-  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, toOrgNumber, appid, 'orgno');
-
+  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:organizationnumber', toOrgNumber);
+  
   // Assert
   var success = check(res, {
     'post MaskinportenSchema To Org Number - status is 201': (r) => r.status === 201,
     'post MaskinportenSchema To Org Number - to id is organizationnumber': (r) => r.json('to.0.id') === 'urn:altinn:organizationnumber',
     'post MaskinportenSchema To Org Number - organization number matches': (r) => r.json('to.0.value') === toOrgNumber,
-    'post MaskinportenSchema To Org Number - resource type is urn:altinn:resourceregistry': (r) => r.json('rightDelegationResults.0.resource.0.id') === 'urn:altinn:resourceregistry',
+    'post MaskinportenSchema To Org Number - resource type is urn:altinn:resource': (r) => r.json('rightDelegationResults.0.resource.0.id') === 'urn:altinn:resource',
     'post MaskinportenSchema To Org Number - appid matches': (r) => r.json('rightDelegationResults.0.resource.0.value') === appid,
     'post MaskinportenSchema To Org Number - action type is action-id': (r) => r.json('rightDelegationResults.0.action.id') === 'urn:oasis:names:tc:xacml:1.0:action:action-id',
-    'post MaskinportenSchema To Org Number - action value is scopeaccess': (r) => r.json('rightDelegationResults.0.action.value') === 'scopeaccess',
+    'post MaskinportenSchema To Org Number - action value is ScopeAccess': (r) => r.json('rightDelegationResults.0.action.value') === 'ScopeAccess',
   });
 
   addErrorCount(success);
@@ -239,11 +271,12 @@ export function postMaskinportenSchemaNotReadyTest() {
   const appid = 'appid-302';
   
   // Act
-  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, toOrgNumber, appid, 'orgno');
+  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:organizationnumber', toOrgNumber);
 
   // Assert
   var success = check(res, {
     'post MaskinportenSchema that is Not Ready - status is 400': (r) => r.status === 400,
+    'post MaskinportenSchema that is Not Ready - `One or more validation errors occurred.`': (r) => r.json('title') == 'One or more validation errors occurred.',
   });
 
   addErrorCount(success);
@@ -255,16 +288,16 @@ export function revokeOfferedMaskinPortenSchema() {
   const offeredByToken = user1_personalToken;
   const offeredByPartyId = org1_partyid;
   const toOrgNumber = org2_number;
-  const appid = 'appid-544';
+  const appid = 'ttd-am-k6';
   
-  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, toOrgNumber, appid, 'orgno');
-  res = maskinporten.getMaskinportenSchemaOffered(offeredByToken, offeredByPartyId);
+  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:organizationnumber', toOrgNumber);
   success = check(res, {
-    'revoke Offered MaskinPortenSchema - getMaskinPortenSchema was added': (r) => r.status === 200,
+    'revoke Offered MaskinPortenSchema - getMaskinPortenSchema was added (status is 201 created)': (r) => r.status === 201,
   });
+  addErrorCount(success);
 
   // Act
-  res = maskinporten.revokeOfferedMaskinportenSchema(offeredByToken, offeredByPartyId, toOrgNumber, appid, 'orgno');
+  res = maskinporten.revokeOfferedMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:organizationnumber', toOrgNumber);
 
   // Assert
   var success = check(res, {
@@ -274,8 +307,9 @@ export function revokeOfferedMaskinPortenSchema() {
 
   res = maskinporten.getMaskinportenSchemaOffered(offeredByToken, offeredByPartyId);
   success = check(res, {
-    'revoke Offered MaskinPortenSchema - getMaskinPortenSchema returns empty list': (r) => r.body == '[]',
+    'revoke Offered MaskinPortenSchema - getMaskinPortenSchema returns only 1 element': (r) => r.json('1') == null,
   });
+  addErrorCount(success);
 }
 
 /** revoke a received maskinportenschema */
@@ -287,13 +321,16 @@ export function revokeReceivedMaskinPortenSchema() {
   const offeredByOrgNumber = org1_number;
   const toOrgNumber = org2_number;
   const toPartyId = org2_partyid;
-  const appid = 'appid-544';
+  const appid = 'ttd-am-k6';
   
-  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, toOrgNumber, appid, 'orgno');
-  res = maskinporten.getMaskinportenSchemaReceived(toToken, toPartyId);
+  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:organizationnumber', toOrgNumber);
+  success = check(res, {
+    'revoke Received MaskinPortenSchema - getMaskinPortenSchema was added (status is 201 created)': (r) => r.status === 201,
+  });
+  addErrorCount(success);
 
   // Act
-  res = maskinporten.revokeReceivedMaskinportenSchema(toToken, toPartyId, offeredByOrgNumber, appid, 'orgno');
+  res = maskinporten.revokeReceivedMaskinportenSchema(toToken, toPartyId, appid, 'urn:altinn:organizationnumber', offeredByOrgNumber);
 
   // Assert
   var success = check(res, {
@@ -303,8 +340,71 @@ export function revokeReceivedMaskinPortenSchema() {
 
   res = maskinporten.getMaskinportenSchemaReceived(toToken, toPartyId);
   success = check(res, {
-    'revoke Received MaskinPortenSchema - getMaskinPortenSchema returns empty list': (r) => r.body == '[]',
+    'revoke Received MaskinPortenSchema - getMaskinPortenSchema returns only 1 element': (r) => r.json('1') == null,
   });
+  addErrorCount(success);
+}
+
+/** revoke an offered maskinportenschema using partyid*/
+export function revokeOfferedMaskinPortenSchemaUsingPartyId() {
+  // Arrange
+  const offeredByToken = user1_personalToken;
+  const offeredByPartyId = org1_partyid;
+  const toPartyId = org2_partyid;
+  const appid = 'ttd-am-k6';
+  
+  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:partyid', toPartyId);
+  success = check(res, {
+    'revoke Offered MaskinPortenSchema using partyid - getMaskinPortenSchema was added (status is 201 created)': (r) => r.status === 201,
+  });
+  addErrorCount(success);
+
+  // Act
+  res = maskinporten.revokeOfferedMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:partyid', toPartyId);
+
+  // Assert
+  var success = check(res, {
+    'revoke Offered MaskinPortenSchema using partyid- revoke status is 204': (r) => r.status === 204,
+  });
+  addErrorCount(success);
+
+  res = maskinporten.getMaskinportenSchemaOffered(offeredByToken, offeredByPartyId);
+  success = check(res, {
+    'revoke Offered MaskinPortenSchema using partyid- getMaskinPortenSchema returns only 1 element': (r) => r.json('1') == null,
+  });
+  addErrorCount(success);
+}
+
+/** revoke a received maskinportenschema using partyid*/
+export function revokeReceivedMaskinPortenSchemaUsingPartyId() {
+  // Arrange
+  const offeredByToken = user1_personalToken;
+  const toToken = user2_personalToken;
+  const offeredByPartyId = org1_partyid;
+  const toPartyId = org2_partyid;
+  const appid = 'ttd-am-k6';
+
+  var res = maskinporten.postMaskinportenSchema(offeredByToken, offeredByPartyId, appid, 'urn:altinn:partyid', toPartyId);
+  success = check(res, {
+    'revoke Received MaskinPortenSchema using partyid - getMaskinPortenSchema was added (status is 201 created)': (r) => r.status === 201,
+  });
+  addErrorCount(success);
+
+  // Act
+  res = maskinporten.revokeReceivedMaskinportenSchema(toToken, toPartyId, appid, 'urn:altinn:partyid', offeredByPartyId);
+
+  // Assert
+  var success = check(res, {
+    'revoke Received MaskinPortenSchema using partyid - status is 204': (r) => r.status === 204,
+  });
+  addErrorCount(success);
+
+  sleep(3);
+  res = maskinporten.getMaskinportenSchemaReceived(toToken, toPartyId);
+  success = check(res, {
+    'revoke Received MaskinPortenSchema using partyid - getMaskinPortenSchema returns only 1 element': (r) => r.json('1') == null,
+  });
+  addErrorCount(success);
 }
 
 /** try to revoke a non-existent offered maskinportenschema */
@@ -315,10 +415,12 @@ export function revokeNonExistentOfferedMaskinPortenSchema() {
   const toOrgNumber = org2_number;
   
   // Act
-  var res = maskinporten.revokeOfferedMaskinportenSchema(offeredByToken, offeredByPartyId, toOrgNumber, 'nonexistent-maskinportenschema-1337', 'orgno');
+  // var res = maskinporten.revokeOfferedMaskinportenSchema(offeredByToken, offeredByPartyId, toOrgNumber, 'digdir-maskinportenschemaid-570', 'orgno');
+  var res = maskinporten.revokeOfferedMaskinportenSchema(offeredByToken, offeredByPartyId, 'nonexistentmaskinportenschema', 'urn:altinn:organizationnumber', toOrgNumber);  
   // Assert
   var success = check(res, {
     'revoke non-existent Offered MaskinPortenSchema - status is 400': (r) => r.status === 400,
+    'revoke non-existent Offered MaskinPortenSchema - `One or more validation errors occurred.`': (r) => r.json('title') == 'One or more validation errors occurred.',
   });
   addErrorCount(success);
 }
@@ -331,11 +433,13 @@ export function revokeNonExistentReceivedMaskinPortenSchema() {
   const offeredByOrgNumber = org1_number;
   
   // Act
-  var res = maskinporten.revokeReceivedMaskinportenSchema(toToken, toPartyId, offeredByOrgNumber, 'nonexistent-maskinportenschema-1337', 'orgno');
-  
+  // var res = maskinporten.revokeReceivedMaskinportenSchema(toToken, toPartyId, offeredByOrgNumber, 'digdir-maskinportenschemaid-570', 'orgno');
+  var res = maskinporten.revokeReceivedMaskinportenSchema(toToken, toPartyId, 'nonexistentmaskinportenschema', 'urn:altinn:organizationnumber', offeredByOrgNumber); 
+
   // Assert
   var success = check(res, {
     'revoke non-existent Received MaskinPortenSchema - status is 400': (r) => r.status === 400,
+    'revoke non-existent Received MaskinPortenSchema - `One or more validation errors occurred.`': (r) => r.json('title') == 'One or more validation errors occurred.',
   });
   addErrorCount(success);
 }


### PR DESCRIPTION
## Description
-Added non-happyflow tests
-renamed generatePolicyMatch to makeRequestBody
-updated tests to use ttd-am-k6 and ttd-am-k6-nuf resources

## Related Issue(s)
- #368 

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
