### PR TITLE
Updated maskinportenskema tests to only run if environment is AT23

### DIFF
--- a/test/K6/src/tests/maskinporten/maskinporten.js
+++ b/test/K6/src/tests/maskinporten/maskinporten.js
@@ -54,6 +54,11 @@ export const options = {
 };
 
 export function setup() {
+  // Only run tests in AT23
+  if (environment.toLowerCase() != 'at23') {
+    return;
+  }
+
   //generate personal token for user 1
   var tokenGenParams = {
     env: environment,
@@ -97,6 +102,9 @@ export function setup() {
 }
 
 export default function (data) {
+  if (!data) {
+    return;
+  }
   user1_personalToken = data.personalToken1;
   user2_personalToken = data.personalToken2;
   appOwner = data.org;
@@ -418,7 +426,7 @@ export function revokeNonExistentOfferedMaskinPortenSchema() {
   
   // Act
   var res = maskinporten.revokeOfferedMaskinportenSchema(offeredByToken, offeredByPartyId, 'nonexistentmaskinportenschema', 'urn:altinn:organizationnumber', toOrgNumber);  
-  console.log(res.body)
+
   // Assert
   var success = check(res, {
     'revoke non-existent Offered MaskinPortenSchema - status is 400': (r) => r.status === 400,


### PR DESCRIPTION
## Description
Updated maskinportenskema tests to only run if environment is AT23, as the other environments aren't ready yet.

## Related Issue(s)
- #368 

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
