### PR TITLE
Added K6 test for maskinportenschema with offeredby's org number in header

### DIFF
--- a/test/K6/src/api/platform/authorization/maskinporten.js
+++ b/test/K6/src/api/platform/authorization/maskinporten.js
@@ -29,8 +29,8 @@ export function getMaskinportenSchemaReceived(altinnToken, partyid) {
  * @param {*} altinnToken personal token for DAGL of offeredby
  * @param {*} offeredByPartyId the offering party's partyid
  * @param {*} to the receiving organization's party id or organization number
- * @param {*} resourceid the id of the resource to delegate
- * @param {*} orgnoOrPartyId 'orgno' to set id to urn:altinn:organizationnumber
+ * @param {*} toAttributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
+ * @param {*} toAttributeValue the receiver's partyid or organization number
  */
 export function revokeOfferedMaskinportenSchema(altinnToken, offeredByPartyId, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls(offeredByPartyId, 'revokeoffered');
@@ -47,8 +47,8 @@ export function revokeOfferedMaskinportenSchema(altinnToken, offeredByPartyId, r
  * @param {*} altinnToken personal token for DAGL of receiver
  * @param {*} coveredByPartyId the receiving party's partyid
  * @param {*} resourceid the id of the resource to delegate
- * @param {*} attributeId the attribute id for the offerer of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
- * @param {*} attributeValue the offerer's partyid or organization number
+ * @param {*} fromAttributeId the attribute id for the offerer of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
+ * @param {*} fromAttributeValue the offerer's partyid or organization number
  */
 export function revokeReceivedMaskinportenSchema(altinnToken, coveredByPartyId, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls(coveredByPartyId, 'revokereceived');
@@ -65,8 +65,8 @@ export function revokeReceivedMaskinportenSchema(altinnToken, coveredByPartyId, 
  * @param {*} altinnToken personal token for DAGL
  * @param {*} offeredByPartyId the offeredby's party id
  * @param {*} resourceid the id of the resource to delegate
- * @param {*} attributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
- * @param {*} attributeValue the receiver's partyid or organization number
+ * @param {*} toAttributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
+ * @param {*} toAttributeValue the receiver's partyid or organization number
  */
 export function postMaskinportenSchema(altinnToken, offeredByPartyId, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls(offeredByPartyId, 'maskinportenschema');
@@ -83,8 +83,8 @@ export function postMaskinportenSchema(altinnToken, offeredByPartyId, resourceid
  * @param {*} altinnToken personal token for DAGL
  * @param {*} offeredByOrganizationNumber the organization number for the offeredby party
  * @param {*} resourceid the id of the resource to delegate
- * @param {*} attributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
- * @param {*} attributeValue the receiver's partyid or organization number
+ * @param {*} toAttributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
+ * @param {*} toAttributeValue the receiver's partyid or organization number
  */
 export function postMaskinportenSchemaOrgNoInHeader(altinnToken, offeredByOrganizationNumber, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls('organization', 'maskinportenschema');

--- a/test/K6/src/api/platform/authorization/maskinporten.js
+++ b/test/K6/src/api/platform/authorization/maskinporten.js
@@ -61,9 +61,9 @@ export function revokeReceivedMaskinportenSchema(altinnToken, coveredByPartyId, 
 }
 
 /**
- * GET call to get maskinportenschemas that have been received by the current party
+ * POST call to delegate a maskinportenschema where the offeredby's partyid is in the path
  * @param {*} altinnToken personal token for DAGL
- * @param {*} toPartyId party id or organization number of whom that offers the rule
+ * @param {*} offeredByPartyId the offeredby's party id
  * @param {*} resourceid the id of the resource to delegate
  * @param {*} attributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
  * @param {*} attributeValue the receiver's partyid or organization number
@@ -79,7 +79,7 @@ export function postMaskinportenSchema(altinnToken, offeredByPartyId, resourceid
 }
 
 /**
- * GET call to get maskinportenschemas that have been received by the current party
+ * POST call to delegate a maskinportenschema where the offeredby's organization number is in the header
  * @param {*} altinnToken personal token for DAGL
  * @param {*} offeredByOrganizationNumber the organization number for the offeredby party
  * @param {*} resourceid the id of the resource to delegate

--- a/test/K6/src/api/platform/authorization/maskinporten.js
+++ b/test/K6/src/api/platform/authorization/maskinporten.js
@@ -88,7 +88,6 @@ export function postMaskinportenSchema(altinnToken, offeredByPartyId, resourceid
  */
 export function postMaskinportenSchemaOrgNoInHeader(altinnToken, offeredByOrganizationNumber, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls('organization', 'maskinportenschema');
-  console.log(endpoint)
   var params = header.buildHeaderWithRuntimeOrgNumberAndJson(altinnToken, 'personal', offeredByOrganizationNumber);
   var body = [];
   body.push(makeRequestBody(resourceid, attributeId, attributeValue));

--- a/test/K6/src/api/platform/authorization/maskinporten.js
+++ b/test/K6/src/api/platform/authorization/maskinporten.js
@@ -9,7 +9,7 @@ import * as header from '../../../buildrequestheaders.js';
  */
 export function getMaskinportenSchemaOffered(altinnToken, partyid) {
   var endpoint = config.buildMaskinPorteSchemaUrls(partyid, 'offered');
-  var params = header.buildHeaderWithRuntimeAndJson(altinnToken, 'personal');
+  var params = header.buildHeaderWithRuntimeAndJson(altinnToken);
   return http.get(endpoint, params);
 }
 
@@ -20,7 +20,7 @@ export function getMaskinportenSchemaOffered(altinnToken, partyid) {
  */
 export function getMaskinportenSchemaReceived(altinnToken, partyid) {
   var endpoint = config.buildMaskinPorteSchemaUrls(partyid, 'received');
-  var params = header.buildHeaderWithRuntimeAndJson(altinnToken, 'personal');
+  var params = header.buildHeaderWithRuntimeAndJson(altinnToken);
   return http.get(endpoint, params);
 }
 
@@ -34,7 +34,7 @@ export function getMaskinportenSchemaReceived(altinnToken, partyid) {
  */
 export function revokeOfferedMaskinportenSchema(altinnToken, offeredByPartyId, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls(offeredByPartyId, 'revokeoffered');
-  var params = header.buildHeaderWithRuntimeAndJson(altinnToken, 'personal');
+  var params = header.buildHeaderWithRuntimeAndJson(altinnToken);
   var body = [];
   body.push(makeRequestBody(resourceid, attributeId, attributeValue));
   var bodystring = JSON.stringify(body);
@@ -52,7 +52,7 @@ export function revokeOfferedMaskinportenSchema(altinnToken, offeredByPartyId, r
  */
 export function revokeReceivedMaskinportenSchema(altinnToken, coveredByPartyId, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls(coveredByPartyId, 'revokereceived');
-  var params = header.buildHeaderWithRuntimeAndJson(altinnToken, 'personal');
+  var params = header.buildHeaderWithRuntimeAndJson(altinnToken);
   var body = [];
   body.push(makeRequestBody(resourceid, null, null, attributeId, attributeValue));
   var bodystring = JSON.stringify(body);
@@ -70,7 +70,7 @@ export function revokeReceivedMaskinportenSchema(altinnToken, coveredByPartyId, 
  */
 export function postMaskinportenSchema(altinnToken, offeredByPartyId, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls(offeredByPartyId, 'maskinportenschema');
-  var params = header.buildHeaderWithRuntimeAndJson(altinnToken, 'personal');
+  var params = header.buildHeaderWithRuntimeAndJson(altinnToken);
   var body = [];
   body.push(makeRequestBody(resourceid, attributeId, attributeValue));
   var bodystring = JSON.stringify(body);
@@ -88,7 +88,7 @@ export function postMaskinportenSchema(altinnToken, offeredByPartyId, resourceid
  */
 export function postMaskinportenSchemaOrgNoInHeader(altinnToken, offeredByOrganizationNumber, resourceid, attributeId, attributeValue) {
   var endpoint = config.buildMaskinPorteSchemaUrls('organization', 'maskinportenschema');
-  var params = header.buildHeaderWithRuntimeOrgNumberAndJson(altinnToken, 'personal', offeredByOrganizationNumber);
+  var params = header.buildHeaderWithRuntimeOrgNumberAndJson(altinnToken, offeredByOrganizationNumber);
   var body = [];
   body.push(makeRequestBody(resourceid, attributeId, attributeValue));
   var bodystring = JSON.stringify(body);

--- a/test/K6/src/api/platform/authorization/maskinporten.js
+++ b/test/K6/src/api/platform/authorization/maskinporten.js
@@ -79,6 +79,25 @@ export function postMaskinportenSchema(altinnToken, offeredByPartyId, resourceid
 }
 
 /**
+ * GET call to get maskinportenschemas that have been received by the current party
+ * @param {*} altinnToken personal token for DAGL
+ * @param {*} offeredByOrganizationNumber the organization number for the offeredby party
+ * @param {*} resourceid the id of the resource to delegate
+ * @param {*} attributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'
+ * @param {*} attributeValue the receiver's partyid or organization number
+ */
+export function postMaskinportenSchemaOrgNoInHeader(altinnToken, offeredByOrganizationNumber, resourceid, attributeId, attributeValue) {
+  var endpoint = config.buildMaskinPorteSchemaUrls('organization', 'maskinportenschema');
+  console.log(endpoint)
+  var params = header.buildHeaderWithRuntimeOrgNumberAndJson(altinnToken, 'personal', offeredByOrganizationNumber);
+  var body = [];
+  body.push(makeRequestBody(resourceid, attributeId, attributeValue));
+  var bodystring = JSON.stringify(body);
+  bodystring = bodystring.substring(1, bodystring.length-1)
+  return http.post(endpoint, bodystring, params);
+}
+
+/**
  * function to build the request body for maskinportenschema
  * @param {*} resourceid the resourceid for the schema
  * @param {*} toAttributeId the attribute id for the receiver of the schema. 'urn:altinn:partyid' or 'urn:altinn:organizationnumber'

--- a/test/K6/src/buildrequestheaders.js
+++ b/test/K6/src/buildrequestheaders.js
@@ -66,6 +66,19 @@ export function buildHeaderWithRuntimeAndJson(altinnStudioRuntimeCookie, api) {
   return params;
 }
 
+//Function to build headers with altinnStudioRuntimeCookie, JSON content-type, and offeredby's org number and returns a json object
+export function buildHeaderWithRuntimeOrgNumberAndJson(altinnStudioRuntimeCookie, api, organizationNumber) {
+  var params = {
+    headers: {
+      Authorization: 'Bearer ' + altinnStudioRuntimeCookie,
+      'Content-Type': 'application/json',
+      'Altinn-Party-OrganizationNumber': organizationNumber,
+    },
+  };
+  params = addSubscriptionKey(params, appsAccessSubscriptionKey, api);
+  return params;
+}
+
 //Function to build headers with .aspxauth cookie
 export function buildHeaderWithAspxAuth(aspxauthCookie, api) {
   var params = {

--- a/test/K6/src/buildrequestheaders.js
+++ b/test/K6/src/buildrequestheaders.js
@@ -67,7 +67,7 @@ export function buildHeaderWithRuntimeAndJson(altinnStudioRuntimeCookie, api) {
 }
 
 //Function to build headers with altinnStudioRuntimeCookie, JSON content-type, and offeredby's org number and returns a json object
-export function buildHeaderWithRuntimeOrgNumberAndJson(altinnStudioRuntimeCookie, api, organizationNumber) {
+export function buildHeaderWithRuntimeOrgNumberAndJson(altinnStudioRuntimeCookie, organizationNumber) {
   var params = {
     headers: {
       Authorization: 'Bearer ' + altinnStudioRuntimeCookie,
@@ -75,7 +75,7 @@ export function buildHeaderWithRuntimeOrgNumberAndJson(altinnStudioRuntimeCookie
       'Altinn-Party-OrganizationNumber': organizationNumber,
     },
   };
-  params = addSubscriptionKey(params, appsAccessSubscriptionKey, api);
+  params = addSubscriptionKey(params, appsAccessSubscriptionKey);
   return params;
 }
 

--- a/test/K6/src/tests/maskinporten/maskinporten.js
+++ b/test/K6/src/tests/maskinporten/maskinporten.js
@@ -123,6 +123,7 @@ export default function (data) {
   //tests
   postMaskinportenSchemaToOrgNumberTest();
   postMaskinportenSchemaToPartyIdTest();
+  postMaskinportenSchemaWithOrgNoInHeaderTest();
   getMaskinPortenSchemaOfferedInvalidPartyId();
   getMaskinPortenSchemaReceivedInvalidPartyId();
   postMaskinportenSchemaNotReadyTest();
@@ -265,6 +266,32 @@ export function postMaskinportenSchemaToOrgNumberTest() {
     'post MaskinportenSchema To Org Number - appid matches': (r) => r.json('rightDelegationResults.0.resource.0.value') === appid,
     'post MaskinportenSchema To Org Number - action type is action-id': (r) => r.json('rightDelegationResults.0.action.id') === 'urn:oasis:names:tc:xacml:1.0:action:action-id',
     'post MaskinportenSchema To Org Number - action value is ScopeAccess': (r) => r.json('rightDelegationResults.0.action.value') === 'ScopeAccess',
+  });
+
+  addErrorCount(success);
+}
+
+/** offer a maskinportenschema using the offeredby's organization number in the header */
+export function postMaskinportenSchemaWithOrgNoInHeaderTest() {
+  // Arrange
+  const offeredByToken = user1_personalToken;
+  const offeredByPartyId = org1_partyid;
+  const offeredByOrganizationNumber = org1_number;
+  const toPartyId = org2_partyid;
+  const appid = 'ttd-am-k6';
+
+  // Act
+  var res = maskinporten.postMaskinportenSchemaOrgNoInHeader(offeredByToken, offeredByOrganizationNumber, appid, 'urn:altinn:partyid', toPartyId);
+
+  // Assert
+  var success = check(res, {
+    'post MaskinportenSchema with offeredbys orgno in header - status is 201': (r) => r.status === 201,
+    'post MaskinportenSchema with offeredbys orgno in header - to id is partyid': (r) => r.json('to.0.id') === 'urn:altinn:partyid',
+    'post MaskinportenSchema with offeredbys orgno in header - organization number matches': (r) => r.json('to.0.value') === toPartyId,
+    'post MaskinportenSchema with offeredbys orgno in header - resource type is urn:altinn:resource': (r) => r.json('rightDelegationResults.0.resource.0.id') === 'urn:altinn:resource',
+    'post MaskinportenSchema with offeredbys orgno in header - appid matches': (r) => r.json('rightDelegationResults.0.resource.0.value') === appid,
+    'post MaskinportenSchema with offeredbys orgno in header - action type is action-id': (r) => r.json('rightDelegationResults.0.action.id') === 'urn:oasis:names:tc:xacml:1.0:action:action-id',
+    'post MaskinportenSchema with offeredbys orgno in header - action value is ScopeAccess': (r) => r.json('rightDelegationResults.0.action.value') === 'ScopeAccess',
   });
 
   addErrorCount(success);


### PR DESCRIPTION
## Description
Added a test that delegates maskinportenschema using offeredby's orgnumber in header.

## Related Issue(s)
- #277 

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
