### PR TITLE
Remove unused maskinporten schema resource API

### DIFF
--- a/src/Altinn.AccessManagement/Controllers/ResourceController.cs
+++ b/src/Altinn.AccessManagement/Controllers/ResourceController.cs
@@ -72,18 +72,5 @@ namespace Altinn.AccessManagement.Controllers
             _logger.LogInformation("Delegation could not be completed. None of the rules could be processed, indicating invalid or incomplete input:\n{resourcesJson}", resourcesJson);
             return BadRequest("Delegation could not be completed");
         }
-
-        /// <summary>
-        /// Get list of maskinprotenschema resources
-        /// </summary>
-        /// <param name="party">the partyid</param>
-        /// <returns></returns>
-        [HttpGet]
-        [Route("accessmanagement/api/v1/{party}/resources/maskinportenschema")]
-        public async Task<ActionResult<List<ServiceResourceExternal>>> Get([FromRoute] int party)
-        {
-            List<ServiceResource> resources = await _rap.GetResources(ResourceType.MaskinportenSchema);
-            return _mapper.Map<List<ServiceResourceExternal>>(resources);
-        }
     }
 }

--- a/src/Altinn.AccessManagement/Controllers/ResourceController.cs
+++ b/src/Altinn.AccessManagement/Controllers/ResourceController.cs
@@ -1,14 +1,7 @@
 ﻿using System.Text.Json;
-using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Models;
-using Altinn.AccessManagement.Core.Models.ResourceRegistry;
-using Altinn.AccessManagement.Core.Services;
 using Altinn.AccessManagement.Core.Services.Interfaces;
-using Altinn.AccessManagement.Filters;
-using Altinn.AccessManagement.Models;
-using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.AccessManagement.Controllers
@@ -21,22 +14,18 @@ namespace Altinn.AccessManagement.Controllers
     {
         private readonly ILogger _logger;
         private readonly IResourceAdministrationPoint _rap;
-        private readonly IMapper _mapper;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DelegationsController"/> class.
         /// </summary>
         /// <param name="logger">the logger.</param>
         /// <param name="resourceAdministrationPoint">The resource administration point</param>
-        /// <param name="mapper">mapper handler</param>
         public ResourceController(
             ILogger<ResourceController> logger,
-            IResourceAdministrationPoint resourceAdministrationPoint,
-            IMapper mapper)
+            IResourceAdministrationPoint resourceAdministrationPoint)
         {
             _logger = logger;
             _rap = resourceAdministrationPoint;
-            _mapper = mapper;
         }
 
         /// <summary>
@@ -44,10 +33,10 @@ namespace Altinn.AccessManagement.Controllers
         /// </summary>
         /// <param name="resources">List of new Resources to add or update</param>
         /// <returns></returns>
-        [Authorize(Policy = "PlatformAccess")]
         [HttpPost]
         [HttpPut]
         [Route("accessmanagement/api/v1/internal/resources")]
+        [Authorize(Policy = "PlatformAccess")]
         [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<ActionResult> Post([FromBody] List<AccessManagementResource> resources)
         {

--- a/test/Altinn.AccessManagement.Tests/Controllers/ResourceControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/ResourceControllerTest.cs
@@ -251,40 +251,6 @@ namespace Altinn.AccessManagement.Tests.Controllers
             Assert.Equal(expected, actual);
         }
 
-        /// <summary>
-        /// Test case: GetResources returns a list of resources 
-        /// Expected: GetResources returns a list of resources filtered by resourcetype
-        /// </summary>
-        [Fact]
-        public async Task GetResources_valid_resourcetype()
-        {
-            // Arrange
-            List<ServiceResourceExternal> expectedResources = GetExpectedResources(ResourceTypeExternal.MaskinportenSchema);
-
-            string token = PrincipalUtil.GetAccessToken("platform", "resourceregistry");
-            _client.DefaultRequestHeaders.Add("PlatformAccessToken", token);
-
-            // Act
-            HttpResponseMessage response = await _client.GetAsync($"accessmanagement/api/v1/52004219/resources/maskinportenschema");
-            string responseContent = await response.Content.ReadAsStringAsync();
-            var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-            };
-            List<ServiceResourceExternal> actualResources = JsonSerializer.Deserialize<List<ServiceResourceExternal>>(responseContent, options);
-
-            // Assert
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            AssertionUtil.AssertCollections(expectedResources, actualResources, AssertionUtil.AssertResourceExternalEqual);
-        }
-
-        private static List<ServiceResourceExternal> GetExpectedResources(ResourceTypeExternal resourceType)
-        {
-            List<ServiceResourceExternal> resources = new List<ServiceResourceExternal>();
-            resources = TestDataUtil.GetResources(resourceType);
-            return resources;
-        }
-
         private HttpClient GetTestClient()
         {
             HttpClient client = _factory.WithWebHostBuilder(builder =>


### PR DESCRIPTION
## Description
Implementation has already been moved to BFF and can be removed from the access management backend API

## Related Issue(s)
- #309

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
