### PR TITLE
Fix for empty GetPartyList lookups when found in cache

### DIFF
--- a/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
@@ -102,8 +102,12 @@ namespace Altinn.AccessManagement.Core.Services
                 }
             }
 
-            List<Party> remainingParties = await _partiesClient.GetPartiesAsync(partyIdsNotInCache);
+            if (partyIdsNotInCache.Count == 0)
+            {
+                return parties;
+            }
 
+            List<Party> remainingParties = await _partiesClient.GetPartiesAsync(partyIdsNotInCache);
             if (remainingParties.Count > 0)
             {
                 foreach (Party party in remainingParties)


### PR DESCRIPTION
## Description
Fixes a bug in the implementation of ContextRetrievalService.GetPartiesAsync which still makes an empty partyId list lookup to register when all party information is found in cache.

## Related Issue(s)
- #425

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
