### PR TITLE
Hotfix for missing MaskinportenSchema filter and ResourceReference null check

### DIFF
--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IResourceAdministrationPoint.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IResourceAdministrationPoint.cs
@@ -25,9 +25,9 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces
         /// <summary>
         /// Gets a list of Resources from ResourceRegister
         /// </summary>
-        /// <param name="scopes">The scope of the resource</param>
+        /// <param name="scope">The scope of the resource</param>
         /// <returns>resource list based on given scope</returns>
-        Task<List<ServiceResource>> GetResources(string scopes);
+        Task<List<ServiceResource>> GetResources(string scope);
 
         /// <summary>
         /// Gets a list of Resources from ResourceRegister

--- a/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
+++ b/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
@@ -59,9 +59,9 @@ namespace Altinn.AccessManagement.Core.Services
 
             List<ServiceResource> resources = await _contextRetrievalService.GetResources();
 
-            foreach (ServiceResource resource in resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema))
+            foreach (ServiceResource resource in resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema && r.ResourceReferences != null))
             {
-                foreach (ResourceReference reference in resource.ResourceReferences?.Where(rf => rf.ReferenceType == ReferenceType.MaskinportenScope && rf.Reference.Equals(scope)))
+                foreach (ResourceReference reference in resource.ResourceReferences.Where(rf => rf.ReferenceType == ReferenceType.MaskinportenScope && rf.Reference.Equals(scope)))
                 {
                     filteredResources.Add(resource);
                 }

--- a/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
+++ b/src/Altinn.AccessManagement.Core/Services/ResourceAdministrationPoint.cs
@@ -53,20 +53,17 @@ namespace Altinn.AccessManagement.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task<List<ServiceResource>> GetResources(string scopes)
+        public async Task<List<ServiceResource>> GetResources(string scope)
         {
             List<ServiceResource> filteredResources = new List<ServiceResource>();
 
             List<ServiceResource> resources = await _contextRetrievalService.GetResources();
 
-            foreach (ServiceResource resource in resources)
+            foreach (ServiceResource resource in resources.Where(r => r.ResourceType == ResourceType.MaskinportenSchema))
             {
-                foreach (ResourceReference reference in resource.ResourceReferences)
+                foreach (ResourceReference reference in resource.ResourceReferences?.Where(rf => rf.ReferenceType == ReferenceType.MaskinportenScope && rf.Reference.Equals(scope)))
                 {
-                    if (reference != null && reference.Reference.Equals(scopes) && reference.ReferenceType == ReferenceType.MaskinportenScope)
-                    {
-                        filteredResources.Add(resource);
-                    }
+                    filteredResources.Add(resource);
                 }
             }
 


### PR DESCRIPTION
## Description
Added both ResourceType filter and null check on ResourceReferences when getting Resources based on matching Scope reference.

## Related Issue(s)
- #513

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
