### PR TITLE
Rolled back Altinn.Common.AccessTokenClient to version 1.1.3

### DIFF
--- a/src/Altinn.AccessManagement.Core/Altinn.AccessManagement.Core.csproj
+++ b/src/Altinn.AccessManagement.Core/Altinn.AccessManagement.Core.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.7" />
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.2.0" />
 	  <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.24.0" />
 	  <PackageReference Include="Azure.Identity" Version="1.10.4" />


### PR DESCRIPTION
## Description
Rolled back Altinn.Common.AccessTokenClient to version 1.1.3

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
