### PR TITLE
Fixed two tests that only asserted the first item in a list contains …

### DIFF
--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaOfferedTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaOfferedTest.bru
@@ -55,7 +55,7 @@ tests {
     expect(data[0]).to.have.property('coveredByName', 'LARKOLLEN OG FAUSKE');
     expect(data[0]).to.have.property('coveredByOrganizationNumber', testdata.org2.orgno);
     expect(data[0]).to.have.property('performedByUserId', testdata.org1.dagl.userid);
-    expect(data[0]).to.have.property('resourceId', 'ttd-am-k6-nuf');
+    expect(data.map(e=>(e.resourceId))).to.include('ttd-am-k6-nuf');
   
   });
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaReceivedTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaReceivedTest.bru
@@ -55,7 +55,7 @@ tests {
     expect(data[0]).to.have.property('coveredByName', 'LARKOLLEN OG FAUSKE');
     expect(data[0]).to.have.property('coveredByOrganizationNumber', testdata.org2.orgno);
     expect(data[0]).to.have.property('performedByUserId', testdata.org1.dagl.userid);
-    expect(data[0]).to.have.property('resourceId', 'ttd-am-k6-nuf');
+    expect(data.map(e=>(e.resourceId))).to.include('ttd-am-k6-nuf');
   
   });
 }


### PR DESCRIPTION
## Description
Fixed two tests that only asserted the first item in a list contains the property "resourceId": "ttd-am-k6-nuf". They now check if the entire list instead.

## Related Issue(s)
- https://github.com/orgs/Altinn/projects/50/views/2?pane=issue&itemId=45605072

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
