### PR TITLE
Additional API endpoints for AuthorizedParties

### DIFF
--- a/src/Altinn.AccessManagement.Core/Constants/AltinnXacmlConstants.cs
+++ b/src/Altinn.AccessManagement.Core/Constants/AltinnXacmlConstants.cs
@@ -107,24 +107,24 @@ namespace Altinn.AccessManagement.Core.Constants
             public const string ServiceEditionCodeAttribute = "urn:altinn:serviceeditioncode";
 
             /// <summary>
-            /// Last name of a person 
-            /// </summary>
-            public const string LastName = "urn:altinn:lastname";
-
-            /// <summary>
-            /// Username
-            /// </summary>
-            public const string UserName = "urn:altinn:username";
-
-            /// <summary>
-            /// Enterprise username
-            /// </summary>
-            public const string EnterpriseUserName = "urn:altinn:enterpriseusername";
-
-            /// <summary>
             /// Person uuid
             /// </summary>
             public const string PersonUuid = "urn:altinn:person:uuid";
+
+            /// <summary>
+            /// National identity number for a person
+            /// </summary>
+            public const string PersonId = "urn:altinn:person:identifier-no";
+
+            /// <summary>
+            /// Last name of a person 
+            /// </summary>
+            public const string PersonLastName = "urn:altinn:person:lastname";
+
+            /// <summary>
+            /// Person username
+            /// </summary>
+            public const string PersonUserName = "urn:altinn:person:username";
 
             /// <summary>
             /// Enterprise user uuid
@@ -132,9 +132,19 @@ namespace Altinn.AccessManagement.Core.Constants
             public const string EnterpriseUserUuid = "urn:altinn:enterpriseuser:uuid";
 
             /// <summary>
+            /// Enterprise user username
+            /// </summary>
+            public const string EnterpriseUserName = "urn:altinn:enterpriseuser:username";
+
+            /// <summary>
             /// Organization uuid
             /// </summary>
             public const string OrganizationUuid = "urn:altinn:organization:uuid";
+
+            /// <summary>
+            /// Organization number
+            /// </summary>
+            public const string OrganizationId = "urn:altinn:organization:identifier-no";
         }
 
         /// <summary>

--- a/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
+++ b/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
@@ -39,6 +39,21 @@
         /// Policy tag for scope authorization on the proxy API from Altinn II for the maskinporten integration API
         /// </summary>
         public const string POLICY_MASKINPORTEN_DELEGATIONS_PROXY = "MaskinportenDelegationsProxy";
+        
+        /// <summary>
+        /// Policy tag for scope authorization on the resource owner API for getting the Authorized Party list for a third party
+        /// </summary>
+        public const string POLICY_RESOURCEOWNER_AUTHORIZEDPARTIES = "ResourceOwnerAuthorizedParty";
+
+        /// <summary>
+        /// Scope giving access to getting authorized parties for a third party, for which the third party have access to one or more of the resource owners services, apps or resources.
+        /// </summary>
+        public const string SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES = "altinn:resourceowner/authorizedparties";
+
+        /// <summary>
+        /// Scope giving access to getting all authorized parties for a third party
+        /// </summary>
+        public const string SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES_ADMIN = "altinn:resourceowner/authorizedparties.admin";
 
         /// <summary>
         /// Scope giving access to delegations for Maskinporten schemes owned by authenticated party 

--- a/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
+++ b/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
@@ -98,7 +98,7 @@ namespace Altinn.AccessManagement.Core.Helpers
         public static bool TryGetSocialSecurityNumberAttributeMatch(List<AttributeMatch> match, out string ssn)
         {
             ssn = string.Empty;
-            if (match != null && match.Count == 1 && match[0].Id == AltinnXacmlConstants.MatchAttributeIdentifiers.SocialSecurityNumberAttribute)
+            if (match != null && match.Count == 1 && match[0].Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId)
             {
                 ssn = match[0].Value;
                 return true;
@@ -113,8 +113,8 @@ namespace Altinn.AccessManagement.Core.Helpers
         /// <returns>The true if both social security number and last name is found as the only attributes in the collection</returns>
         public static bool TryGetSocialSecurityNumberAndLastNameAttributeMatch(List<AttributeMatch> match, out string ssn, out string lastName)
         {
-            ssn = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.SocialSecurityNumberAttribute)?.Value;
-            lastName = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.LastName)?.Value;
+            ssn = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId)?.Value;
+            lastName = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PersonLastName)?.Value;
 
             if (match.Count == 2 && !string.IsNullOrWhiteSpace(ssn) && !string.IsNullOrWhiteSpace(lastName))
             {
@@ -130,8 +130,8 @@ namespace Altinn.AccessManagement.Core.Helpers
         /// <returns>The true if both username and last name is found as the only attributes in the collection</returns>
         public static bool TryGetUsernameAndLastNameAttributeMatch(List<AttributeMatch> match, out string username, out string lastName)
         {
-            username = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.UserName)?.Value;
-            lastName = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.LastName)?.Value;
+            username = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUserName)?.Value;
+            lastName = match.Find(m => m.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PersonLastName)?.Value;
 
             if (match.Count == 2 && !string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(lastName))
             {

--- a/src/Altinn.AccessManagement.Core/Models/AuthorizedParty/AuthorizedParty.cs
+++ b/src/Altinn.AccessManagement.Core/Models/AuthorizedParty/AuthorizedParty.cs
@@ -80,11 +80,6 @@ public class AuthorizedParty
     public bool OnlyHierarchyElementWithNoAccess { get; set; }
 
     /// <summary>
-    /// Gets or sets the value of ChildParties
-    /// </summary>
-    public List<AuthorizedParty> ChildParties { get; set; } = [];
-
-    /// <summary>
     /// Gets or sets a collection of all resource identifier the authorized actor has been authorized with some right for, on behalf of this party
     /// </summary>
     public List<string> AuthorizedResources { get; set; } = [];
@@ -95,9 +90,9 @@ public class AuthorizedParty
     public List<string> AuthorizedRoles { get; set; } = [];
 
     /// <summary>
-    /// Gets or sets a collection of all access packages from Altinn 3 which the authorized actor has been authorized for, on behalf of this party
+    /// Gets or sets the value of ChildParties
     /// </summary>
-    public List<string> AuthorizedAccessPackages { get; set; } = [];
+    public List<AuthorizedParty> ChildParties { get; set; } = [];
 
     /// <summary>
     /// Enriches this authorized party and any child/subunits with the list of authorized resources

--- a/src/Altinn.AccessManagement.Core/Models/BaseAttribute.cs
+++ b/src/Altinn.AccessManagement.Core/Models/BaseAttribute.cs
@@ -1,0 +1,56 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.AccessManagement.Models;
+
+/// <summary>
+/// This model describes a an Attribute consisting of an Attribute Type and Attribute Value which can also be represented as a Urn by combining the properties as '{type}:{value}'
+/// It's used both for external API input/output but also internally for working with attributes and matching to XACML-attributes used in policies, indentifying for instance a resource, a user, a party or an action.
+/// </summary>
+public class BaseAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseAttribute"/> class.
+    /// </summary>
+    public BaseAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseAttribute"/> class.
+    /// </summary>
+    public BaseAttribute(string type, string value)
+    {
+        Type = type;
+        Value = value;
+        Urn = $"{type}:{value}";
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaseAttribute"/> class.
+    /// </summary>
+    public BaseAttribute(string urn)
+    {
+        int valuePos = urn.LastIndexOf(':') + 1;
+        Urn = urn;
+        Type = urn.Substring(0, valuePos - 1);
+        Value = urn.Substring(valuePos);
+    }
+
+    /// <summary>
+    /// Gets or sets the attribute id for the match
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the attribute value for the match
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the attribute value for the match
+    /// </summary>
+    [JsonPropertyName("urn")]
+    public string Urn { get; set; }
+}

--- a/src/Altinn.AccessManagement.Core/Services/Altinn2RightsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Altinn2RightsService.cs
@@ -1,116 +1,38 @@
-using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Constants;
-using Altinn.AccessManagement.Core.Helpers.Extensions;
 using Altinn.AccessManagement.Core.Models;
-using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Core.Services.Interfaces;
-using Altinn.Platform.Register.Enums;
 
 namespace Altinn.AccessManagement.Core.Services;
 
 /// <inheritdoc/>
 public class Altinn2RightsService : IAltinn2RightsService
 {
-    private readonly IDelegationMetadataRepository _delegationRepository;
     private readonly IContextRetrievalService _contextRetrievalService;
-    private readonly IProfileClient _profile;
+    private readonly IPolicyInformationPoint _pip;
 
     /// <summary>
-    /// ctor
+    /// Initializes a new instance of the <see cref="Altinn2RightsService"/> class.
     /// </summary>
-    /// <param name="delegationRepository">database implementation for fetching and inserting delegations</param>
     /// <param name="contextRetrievalService">Service for retrieving context information</param>
-    /// <param name="profile">Client implementation for getting user profile</param>
-    public Altinn2RightsService(IDelegationMetadataRepository delegationRepository, IContextRetrievalService contextRetrievalService, IProfileClient profile)
+    /// <param name="pip">Service for getting policy information</param>
+    public Altinn2RightsService(IContextRetrievalService contextRetrievalService, IPolicyInformationPoint pip)
     {
-        _delegationRepository = delegationRepository;
         _contextRetrievalService = contextRetrievalService;
-        _profile = profile;
+        _pip = pip;
     }
 
     /// <inheritdoc/>
     public async Task<IEnumerable<RightDelegation>> GetOfferedRights(int partyId, CancellationToken cancellationToken = default)
     {
-        var delegations = await GetOfferedDelegationsFromRepository(partyId, cancellationToken);
+        var delegations = await _pip.GetOfferedDelegationsFromRepository(partyId, cancellationToken);
         return await MapDelegationResponse(delegations);
     }
 
     /// <inheritdoc/>
     public async Task<List<RightDelegation>> GetReceivedRights(int partyId, CancellationToken cancellationToken = default)
     {
-        var delegations = await GetReceivedDelegationFromRepository(partyId, cancellationToken);
+        var delegations = await _pip.GetReceivedDelegationFromRepository(partyId, cancellationToken);
         return await MapDelegationResponse(delegations);
-    }
-
-    /// <summary>
-    /// returns the reportee's received delegations from db 
-    /// </summary>
-    /// <param name="partyId">reportee</param>
-    /// <param name="cancellationToken">cancellation token</param>
-    /// <returns></returns>
-    private async Task<IEnumerable<DelegationChange>> GetReceivedDelegationFromRepository(int partyId, CancellationToken cancellationToken)
-    {
-        var party = await _contextRetrievalService.GetPartyAsync(partyId);
-
-        if (party?.PartyTypeName == PartyType.Person)
-        {
-            var user = await _profile.GetUser(new()
-            {
-                Ssn = party.SSN,
-            });
-
-            var keyRoles = await _contextRetrievalService.GetKeyRolePartyIds(user.UserId, cancellationToken);
-            return await _delegationRepository.GetAllDelegationChangesForAuthorizedParties(user.UserId.SingleToList(), keyRoles, cancellationToken);
-        }
-
-        if (party?.PartyTypeName == PartyType.Organisation)
-        {
-            return await _delegationRepository.GetAllDelegationChangesForAuthorizedParties(null, party.PartyId.SingleToList(), cancellationToken);
-        }
-
-        throw new ArgumentException($"failed to handle party with id '{partyId}'");
-    }
-
-    /// <summary>
-    /// returns the reportee's offereds delegations from db
-    /// </summary>
-    /// <param name="partyId">reportee</param>
-    /// <param name="cancellationToken">cancellation token</param>
-    /// <returns></returns>
-    private async Task<IEnumerable<DelegationChange>> GetOfferedDelegationsFromRepository(int partyId, CancellationToken cancellationToken)
-    {
-        var party = await _contextRetrievalService.GetPartyAsync(partyId);
-
-        if (party.PartyTypeName == PartyType.Person)
-        {
-            var user = await _profile.GetUser(new()
-            {
-                Ssn = party.SSN
-            });
-
-            var keyRoles = await _contextRetrievalService.GetKeyRolePartyIds(user.UserId, cancellationToken);
-            var offeredBy = user.PartyId.SingleToList();
-            if (keyRoles.Count > 0)
-            {
-                offeredBy.AddRange(keyRoles);
-            }
-
-            return await _delegationRepository.GetOfferedDelegations(offeredBy, cancellationToken);
-        }
-
-        if (party.PartyTypeName == PartyType.Organisation)
-        {
-            var mainUnits = await _contextRetrievalService.GetMainUnits(party.PartyId.SingleToList(), cancellationToken);
-            var parties = party.PartyId.SingleToList();
-            if (mainUnits?.FirstOrDefault() is var mainUnit && mainUnit?.PartyId != null)
-            {
-                parties.Add((int)mainUnit.PartyId);
-            }
-
-            return await _delegationRepository.GetOfferedDelegations(parties, cancellationToken);
-        }
-
-        throw new ArgumentException($"failed to handle party with id '{partyId}'");
     }
 
     private async Task<List<RightDelegation>> MapDelegationResponse(IEnumerable<DelegationChange> delegations)

--- a/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
@@ -1,10 +1,14 @@
 ﻿using System.Diagnostics;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
+using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Helpers.Extensions;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.SblBridge;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.AccessManagement.Models;
+using Altinn.Platform.Profile.Models;
+using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 
 namespace Altinn.AccessManagement.Core.Services;
@@ -15,6 +19,7 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
     private readonly IContextRetrievalService _contextRetrievalService;
     private readonly IDelegationMetadataRepository _delegations;
     private readonly IAltinnRolesClient _altinnRolesClient;
+    private readonly IProfileClient _profile;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AuthorizedPartiesService"/> class.
@@ -22,23 +27,153 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
     /// <param name="contextRetrievalService">Service for retrieving context information</param>
     /// <param name="delegations">Database repository for delegations</param>
     /// <param name="altinn2">SBL bridge client for role and reportee information from Altinn 2</param>
-    public AuthorizedPartiesService(IContextRetrievalService contextRetrievalService, IDelegationMetadataRepository delegations, IAltinnRolesClient altinn2)
+    /// <param name="profile">Service implementation for user profile retrieval</param>
+    public AuthorizedPartiesService(IContextRetrievalService contextRetrievalService, IDelegationMetadataRepository delegations, IAltinnRolesClient altinn2, IProfileClient profile)
     {
         _contextRetrievalService = contextRetrievalService;
         _delegations = delegations;
         _altinnRolesClient = altinn2;
+        _profile = profile;
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedParties(int authenticatedUserId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedParties(BaseAttribute subjectAttribute, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken) => subjectAttribute.Type switch
+    {
+        AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId => await GetAuthorizedPartiesForPerson(subjectAttribute.Value.ToString(), includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationId => await GetAuthorizedPartiesForOrganization(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName => await GetAuthorizedPartiesForEnterpriseUser(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUuid => await GetAuthorizedPartiesForPersonUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationUuid => await GetAuthorizedPartiesForOrganizationUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserUuid => await GetAuthorizedPartiesForEnterpriseUserUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute => await GetAuthorizedPartiesForParty(int.Parse(subjectAttribute.Value), includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute => await GetAuthorizedPartiesForUser(int.Parse(subjectAttribute.Value), includeAltinn2AuthorizedParties, cancellationToken),
+        _ => throw new ArgumentException(message: $"Unknown attribute type: {subjectAttribute.Type}", paramName: nameof(subjectAttribute.Type))
+    };
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForParty(int subjectPartyId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        Party subject = await _contextRetrievalService.GetPartyAsync(subjectPartyId);
+        if (subject?.PartyTypeName == PartyType.Person)
+        {
+            UserProfile user = await _profile.GetUser(new() { Ssn = subject.SSN });
+            if (user != null)
+            {
+                return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+            }
+        }
+
+        if (subject?.PartyTypeName == PartyType.Organisation)
+        {
+            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, cancellationToken);
+        }
+
+        return await Task.FromResult(new List<AuthorizedParty>());
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForUser(int subjectUserId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        List<int> keyRoleUnits = await _contextRetrievalService.GetKeyRolePartyIds(subjectUserId, cancellationToken);
+        return await BuildAuthorizedParties(subjectUserId, keyRoleUnits, includeAltinn2AuthorizedParties, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForPerson(string subjectNationalId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        UserProfile user = await _profile.GetUser(new() { Ssn = subjectNationalId });
+        if (user != null)
+        {
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+        }
+
+        return await Task.FromResult(new List<AuthorizedParty>());
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForPersonUuid(string subjectPersonUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(subjectPersonUuid, out Guid personUuid))
+        {
+            throw new ArgumentException(message: $"Not a well-formed uuid: {subjectPersonUuid}", paramName: nameof(subjectPersonUuid));
+        }
+
+        UserProfile user = await _profile.GetUser(new() { UserUuid = personUuid });
+        if (user != null && user.Party.PartyTypeName == PartyType.Person)
+        {
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+        }
+
+        return await Task.FromResult(new List<AuthorizedParty>());
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganization(string subjectOrganizationNumber, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        Party subject = await _contextRetrievalService.GetPartyForOrganization(subjectOrganizationNumber);
+        if (subject != null)
+        {
+            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, cancellationToken);
+        }
+
+        return await Task.FromResult(new List<AuthorizedParty>());
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganizationUuid(string subjectOrganizationUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(subjectOrganizationUuid, out Guid orgUuid))
+        {
+            throw new ArgumentException(message: $"Not a well-formed uuid: {subjectOrganizationUuid}", paramName: nameof(subjectOrganizationUuid));
+        }
+
+        Party subject = await _contextRetrievalService.GetPartyByUuid(orgUuid);
+        if (subject != null && subject.PartyTypeName == PartyType.Organisation)
+        {
+            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, cancellationToken);
+        }
+
+        return await Task.FromResult(new List<AuthorizedParty>());
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUser(string subjectEnterpriseUsername, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        UserProfile user = await _profile.GetUser(new() { Username = subjectEnterpriseUsername });
+        if (user != null && user.Party.PartyTypeName == PartyType.Organisation)
+        {
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+        }
+
+        return await Task.FromResult(new List<AuthorizedParty>());
+    }
+
+    /// <inheritdoc/>
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUserUuid(string subjectEnterpriseUserUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(subjectEnterpriseUserUuid, out Guid enterpriseUserUuid))
+        {
+            throw new ArgumentException(message: $"Not a well-formed uuid: {subjectEnterpriseUserUuid}", paramName: nameof(subjectEnterpriseUserUuid));
+        }
+
+        UserProfile user = await _profile.GetUser(new() { UserUuid = enterpriseUserUuid });
+        if (user != null && user.Party.PartyTypeName == PartyType.Organisation)
+        {
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+        }
+
+        return await Task.FromResult(new List<AuthorizedParty>());
+    }
+
+    private async Task<List<AuthorizedParty>> BuildAuthorizedParties(int subjectUserId, List<int> subjectPartyIds, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
     {
         List<AuthorizedParty> result = new();
         List<AuthorizedParty> a3AuthParties = new();
         SortedDictionary<int, AuthorizedParty> authorizedPartyDict = [];
 
-        if (includeAltinn2AuthorizedParties)
+        if (includeAltinn2AuthorizedParties && subjectUserId != 0)
         {
-            List<AuthorizedParty> a2AuthParties = await _altinnRolesClient.GetAuthorizedPartiesWithRoles(authenticatedUserId, cancellationToken);
+            List<AuthorizedParty> a2AuthParties = await _altinnRolesClient.GetAuthorizedPartiesWithRoles(subjectUserId, cancellationToken);
             foreach (AuthorizedParty a2Party in a2AuthParties)
             {
                 authorizedPartyDict.Add(a2Party.PartyId, a2Party);
@@ -56,16 +191,14 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
 
         //// To-be-implemented: Find all authorized resources through roles (needs RR Role - Resource API)
 
-        // Find all needed datasets: A3 delegations (direct and inherited), KeyRole-relations, MainUnits, Subunits and Parties
-        List<int> keyRoleUnits = await _contextRetrievalService.GetKeyRolePartyIds(authenticatedUserId, cancellationToken);
-        List<DelegationChange> delegations = await _delegations.GetAllDelegationChangesForAuthorizedParties(authenticatedUserId.SingleToList(), keyRoleUnits, cancellationToken: cancellationToken);
+        List<DelegationChange> delegations = await _delegations.GetAllDelegationChangesForAuthorizedParties(subjectUserId != 0 ? subjectUserId.SingleToList() : null, subjectPartyIds, cancellationToken: cancellationToken);
 
         List<int> fromPartyIds = delegations.Select(dc => dc.OfferedByPartyId).Distinct().ToList();
         List<MainUnit> mainUnits = await _contextRetrievalService.GetMainUnits(fromPartyIds, cancellationToken);
 
         fromPartyIds.AddRange(mainUnits.Where(m => m.PartyId.HasValue).Select(m => m.PartyId.Value));
         List<Party> delegationParties = await _contextRetrievalService.GetPartiesAsync(fromPartyIds, true, cancellationToken);
-        
+
         foreach (var delegation in delegations)
         {
             if (!authorizedPartyDict.TryGetValue(delegation.OfferedByPartyId, out AuthorizedParty authorizedParty))

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IAuthorizedPartiesService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IAuthorizedPartiesService.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Core.Services.Interfaces;
 
@@ -8,11 +9,83 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces;
 public interface IAuthorizedPartiesService
 {
     /// <summary>
-    /// Gets the full unfiltered list of authorized parties the given user can represent in Altinn
+    /// Gets the full unfiltered list of all authorized parties a given user or organization have some access for in Altinn
     /// </summary>
-    /// <param name="authenticatedUserId">The user id of the authenticated user to retrieve the authorized party list for</param>
+    /// <param name="subjectAttribute">Attribute identifying the user or organization retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    public Task<List<AuthorizedParty>> GetAuthorizedParties(int authenticatedUserId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedParties(BaseAttribute subjectAttribute, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given user can represent in Altinn
+    /// </summary>
+    /// <param name="subjectUserId">The user id of the user to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForUser(int subjectUserId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given user or organization have some access for in Altinn
+    /// </summary>
+    /// <param name="subjectPartyId">The party id of the user or organization to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForParty(int subjectPartyId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given person can represent in Altinn
+    /// </summary>
+    /// <param name="subjectNationalId">The national identity number of the person to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForPerson(string subjectNationalId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given person can represent in Altinn
+    /// </summary>
+    /// <param name="subjectPersonUuid">The uuid of the person to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForPersonUuid(string subjectPersonUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given organization can represent in Altinn
+    /// </summary>
+    /// <param name="subjectOrganizationNumber">The organization number of the organization to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganization(string subjectOrganizationNumber, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given organization can represent in Altinn
+    /// </summary>
+    /// <param name="subjectOrganizationUuid">The organization uuid of the organization to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganizationUuid(string subjectOrganizationUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given enterprise user can represent in Altinn
+    /// </summary>
+    /// <param name="subjectEnterpriseUsername">The username of the enterprise user to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUser(string subjectEnterpriseUsername, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the full unfiltered list of authorized parties the given enterprise user can represent in Altinn
+    /// </summary>
+    /// <param name="subjectEnterpriseUserUuid">The uuid of the enterprise user to retrieve the authorized party list for</param>
+    /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>The unfiltered party list</returns>
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUserUuid(string subjectEnterpriseUserUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
 }

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IPolicyInformationPoint.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IPolicyInformationPoint.cs
@@ -32,5 +32,21 @@ namespace Altinn.AccessManagement.Core.Services.Interfaces
         /// <param name="request">The object containing the resource/app that's checked for delegation changes</param>
         /// <returns>A list of delegation changes that's stored in the database</returns>
         Task<DelegationChangeList> GetAllDelegations(DelegationChangeInput request);
+
+        /// <summary>
+        /// Finds all active received delegations (not including maskinporten schema) from db, both directly delegated to the party or through key roles if the party is a person
+        /// </summary>
+        /// <param name="partyId">Party id of a user or organization</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+        /// <returns></returns>
+        Task<IEnumerable<DelegationChange>> GetReceivedDelegationFromRepository(int partyId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Finds all active offered delegations (not including maskinporten schema) from db, both directly delegated from the party or from it's main unit if the party is a subunit
+        /// </summary>
+        /// <param name="partyId">Party id of a user or organization</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+        /// <returns></returns>
+        Task<IEnumerable<DelegationChange>> GetOfferedDelegationsFromRepository(int partyId, CancellationToken cancellationToken);
     }
 }

--- a/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
+++ b/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Enums;
 using Altinn.AccessManagement.Core.Helpers;
@@ -10,6 +11,7 @@ using Altinn.AccessManagement.Core.Services.Interfaces;
 using Altinn.Authorization.ABAC;
 using Altinn.Authorization.ABAC.Constants;
 using Altinn.Authorization.ABAC.Xacml;
+using Altinn.Platform.Register.Enums;
 using Authorization.Platform.Authorization.Models;
 using Microsoft.Extensions.Logging;
 
@@ -24,6 +26,7 @@ namespace Altinn.AccessManagement.Core.Services
         private readonly IPolicyRetrievalPoint _prp;
         private readonly IDelegationMetadataRepository _delegationRepository;
         private readonly IContextRetrievalService _contextRetrievalService;
+        private readonly IProfileClient _profile;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolicyInformationPoint"/> class.
@@ -32,12 +35,14 @@ namespace Altinn.AccessManagement.Core.Services
         /// <param name="policyRetrievalPoint">The policy retrieval point</param>
         /// <param name="delegationRepository">The delegation change repository</param>
         /// <param name="contextRetrievalService">Service for retrieving context information</param>
-        public PolicyInformationPoint(ILogger<IPolicyInformationPoint> logger, IPolicyRetrievalPoint policyRetrievalPoint, IDelegationMetadataRepository delegationRepository, IContextRetrievalService contextRetrievalService)
+        /// <param name="profile">Service for retrieving user profile information</param>
+        public PolicyInformationPoint(ILogger<IPolicyInformationPoint> logger, IPolicyRetrievalPoint policyRetrievalPoint, IDelegationMetadataRepository delegationRepository, IContextRetrievalService contextRetrievalService, IProfileClient profile)
         {
             _logger = logger;
             _prp = policyRetrievalPoint;
             _delegationRepository = delegationRepository;
             _contextRetrievalService = contextRetrievalService;
+            _profile = profile;
         }
 
         /// <inheritdoc/>
@@ -139,7 +144,68 @@ namespace Altinn.AccessManagement.Core.Services
 
             return result.Values.Where(r => r.HasPermit.HasValue && r.HasPermit.Value).ToList();
         }
-        
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<DelegationChange>> GetReceivedDelegationFromRepository(int partyId, CancellationToken cancellationToken)
+        {
+            var party = await _contextRetrievalService.GetPartyAsync(partyId);
+
+            if (party?.PartyTypeName == PartyType.Person)
+            {
+                var user = await _profile.GetUser(new()
+                {
+                    Ssn = party.SSN,
+                });
+
+                var keyRoles = await _contextRetrievalService.GetKeyRolePartyIds(user.UserId, cancellationToken);
+                return await _delegationRepository.GetAllDelegationChangesForAuthorizedParties(user.UserId.SingleToList(), keyRoles, cancellationToken);
+            }
+
+            if (party?.PartyTypeName == PartyType.Organisation)
+            {
+                return await _delegationRepository.GetAllDelegationChangesForAuthorizedParties(null, party.PartyId.SingleToList(), cancellationToken);
+            }
+
+            throw new ArgumentException($"failed to handle party with id '{partyId}'");
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<DelegationChange>> GetOfferedDelegationsFromRepository(int partyId, CancellationToken cancellationToken)
+        {
+            var party = await _contextRetrievalService.GetPartyAsync(partyId);
+
+            if (party.PartyTypeName == PartyType.Person)
+            {
+                var user = await _profile.GetUser(new()
+                {
+                    Ssn = party.SSN
+                });
+
+                var keyRoles = await _contextRetrievalService.GetKeyRolePartyIds(user.UserId, cancellationToken);
+                var offeredBy = user.PartyId.SingleToList();
+                if (keyRoles.Count > 0)
+                {
+                    offeredBy.AddRange(keyRoles);
+                }
+
+                return await _delegationRepository.GetOfferedDelegations(offeredBy, cancellationToken);
+            }
+
+            if (party.PartyTypeName == PartyType.Organisation)
+            {
+                var mainUnits = await _contextRetrievalService.GetMainUnits(party.PartyId.SingleToList(), cancellationToken);
+                var parties = party.PartyId.SingleToList();
+                if (mainUnits?.FirstOrDefault() is var mainUnit && mainUnit?.PartyId != null)
+                {
+                    parties.Add((int)mainUnit.PartyId);
+                }
+
+                return await _delegationRepository.GetOfferedDelegations(parties, cancellationToken);
+            }
+
+            throw new ArgumentException($"failed to handle party with id '{partyId}'");
+        }
+
         /// <inheritdoc/>
         public async Task<DelegationChangeList> GetAllDelegations(DelegationChangeInput request)
         {

--- a/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
@@ -381,7 +381,7 @@ namespace Altinn.AccessManagement.Core.Services
 
             if (toParty == null && toUser == null)
             {
-                result.Errors.Add("To", $"A distinct recipient party for the delegation, could not be identified by the supplied attributes. A recipient can be identified by either a single {AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationNumberAttribute} or {AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName} attribute, or a combination of {AltinnXacmlConstants.MatchAttributeIdentifiers.SocialSecurityNumberAttribute} and {AltinnXacmlConstants.MatchAttributeIdentifiers.LastName} attributes, or {AltinnXacmlConstants.MatchAttributeIdentifiers.UserName} and {AltinnXacmlConstants.MatchAttributeIdentifiers.LastName} attributes.");
+                result.Errors.Add("To", $"A distinct recipient party for the delegation, could not be identified by the supplied attributes. A recipient can be identified by either a single {AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationNumberAttribute} or {AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName} attribute, or a combination of {AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId} and {AltinnXacmlConstants.MatchAttributeIdentifiers.PersonLastName} attributes, or {AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUserName} and {AltinnXacmlConstants.MatchAttributeIdentifiers.PersonLastName} attributes.");
                 return (result, resource, null, null);
             }
 

--- a/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
+++ b/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
@@ -1,8 +1,10 @@
 ﻿using System.Net.Mime;
 using Altinn.AccessManagement.Core.Configuration;
+using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Helpers;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.AccessManagement.Models;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -65,9 +67,96 @@ public class AuthorizedPartiesController : ControllerBase
                 return Unauthorized();
             }
 
-            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedParties(userId, includeAltinn2, cancellationToken);
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, cancellationToken);
 
             return _mapper.Map<List<AuthorizedPartyExternal>>(authorizedParties);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(500, ex, "Unexpected internal exception occurred during GetAuthorizedParties");
+            return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, detail: "Internal Server Error"));
+        }
+    }
+
+    /// <summary>
+    /// Endpoint for retrieving a given authorized party if it exists (with option to include Authorized Parties, aka Reportees from Altinn 2, when getting the underlying list of authorized parties) in the authenticated user's list of authorized parties
+    /// </summary>
+    /// <param name="partyId">The partyId to get if exists in the authenticated user's list of authorized parties</param>
+    /// <param name="includeAltinn2">Optional (Default: False): Whether Authorized Parties from Altinn 2 should be included in the underlying result set, and if access to Altinn 3 resources through having Altinn 2 roles should be included.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <response code="200" cref="List{AuthorizedParty}">Ok</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="403">Forbidden</response>
+    /// <response code="500">Internal Server Error</response>
+    [HttpGet]
+    [Authorize]
+    [Route("authorizedparty/{partyId}")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(List<AuthorizedPartyExternal>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    [FeatureGate(FeatureFlags.RightsDelegationApi)]
+    public async Task<ActionResult<AuthorizedPartyExternal>> GetAuthorizedParty([FromRoute] int partyId, bool includeAltinn2 = false, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            int userId = AuthenticationHelper.GetUserId(HttpContext);
+            if (userId == 0)
+            {
+                return Unauthorized();
+            }
+
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, cancellationToken);
+            AuthorizedParty authorizedParty = authorizedParties.Find(p => p.PartyId == partyId);
+
+            if (authorizedParty == null)
+            {
+                return Forbid();
+            }
+
+            return _mapper.Map<AuthorizedPartyExternal>(authorizedParty);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(500, ex, "Unexpected internal exception occurred during GetAuthorizedParties");
+            return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, detail: "Internal Server Error"));
+        }
+    }
+
+    /// <summary>
+    /// Endpoint for retrieving all authorized parties (with option to include Authorized Parties, aka Reportees, from Altinn 2) for the authenticated user
+    /// </summary>
+    /// <param name="party">The party to retrieve the list of authorized parties for</param>
+    /// <param name="includeAltinn2">Optional (Default: False): Whether Authorized Parties from Altinn 2 should be included in the result set, and if access to Altinn 3 resources through having Altinn 2 roles should be included.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <response code="200" cref="List{AuthorizedParty}">Ok</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="403">Forbidden</response>
+    /// <response code="500">Internal Server Error</response>
+    [HttpGet]
+    [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ)]
+    [Route("{party}/authorizedparties")]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(List<AuthorizedPartyExternal>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    [FeatureGate(FeatureFlags.RightsDelegationApi)]
+    public async Task<ActionResult<List<AuthorizedPartyExternal>>> GetAuthorizedPartiesAsAccessManager([FromRoute] string party, bool includeAltinn2 = false, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            BaseAttribute subject = new() { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, Value = party };
+
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedParties(subject, includeAltinn2, cancellationToken);
+
+            return _mapper.Map<List<AuthorizedPartyExternal>>(authorizedParties);
+        }
+        catch (ArgumentException ex)
+        {
+            ModelState.AddModelError("Argument exception", ex.Message);
+            return new ObjectResult(ProblemDetailsFactory.CreateValidationProblemDetails(HttpContext, ModelState));
         }
         catch (Exception ex)
         {

--- a/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesController.cs
+++ b/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesController.cs
@@ -1,0 +1,81 @@
+﻿using System.Net.Mime;
+using Altinn.AccessManagement.Core.Configuration;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.AccessManagement.Models;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+
+namespace Altinn.AccessManagement.Controllers;
+
+/// <summary>
+/// Controller responsible for all operations for retrieving AuthorizedParties list for a user / organization / system
+/// </summary>
+[ApiController]
+[Route("accessmanagement/api/v1/resourceowner")]
+public class ResourceOwnerAuthorizedPartiesController : ControllerBase
+{
+    private readonly ILogger _logger;
+    private readonly IMapper _mapper;
+    private readonly IAuthorizedPartiesService _authorizedPartiesService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResourceOwnerAuthorizedPartiesController"/> class.
+    /// </summary>
+    /// <param name="logger">logger service</param>
+    /// <param name="mapper">mapper service</param>
+    /// <param name="authorizedPartiesService">service implementation for authorized parties</param>
+    public ResourceOwnerAuthorizedPartiesController(
+        ILogger<ResourceOwnerAuthorizedPartiesController> logger,
+        IMapper mapper,
+        IAuthorizedPartiesService authorizedPartiesService)
+    {
+        _logger = logger;
+        _mapper = mapper;
+        _authorizedPartiesService = authorizedPartiesService;
+    }
+
+    /// <summary>
+    /// Endpoint for retrieving all authorized parties (with option to include Authorized Parties, aka Reportees, from Altinn 2) for a given user or organization 
+    /// </summary>
+    /// <param name="subject">Subject input model identifying the user or organization to retrieve the list of authorized parties for</param>
+    /// <param name="includeAltinn2">Optional (Default: False): Whether Authorized Parties from Altinn 2 should be included in the result set, and if access to Altinn 3 resources through having Altinn 2 roles should be included.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <response code="200" cref="List{AuthorizedParty}">Ok</response>
+    /// <response code="401">Unauthorized</response>
+    /// <response code="403">Forbidden</response>
+    /// <response code="500">Internal Server Error</response>
+    [HttpPost]
+    [Authorize(Policy = AuthzConstants.POLICY_RESOURCEOWNER_AUTHORIZEDPARTIES)]
+    [Route("authorizedparties")]
+    [Consumes(MediaTypeNames.Application.Json)]
+    [Produces(MediaTypeNames.Application.Json)]
+    [ProducesResponseType(typeof(List<AuthorizedPartyExternal>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    [FeatureGate(FeatureFlags.RightsDelegationApi)]
+    public async Task<ActionResult<List<AuthorizedPartyExternal>>> GetAuthorizedPartiesAsServiceOwner(BaseAttributeExternal subject, bool includeAltinn2 = false, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            BaseAttribute subjectAttribute = _mapper.Map<BaseAttribute>(subject);
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedParties(subjectAttribute, includeAltinn2, cancellationToken);
+
+            return _mapper.Map<List<AuthorizedPartyExternal>>(authorizedParties);
+        }
+        catch (ArgumentException ex)
+        {
+            ModelState.AddModelError("Argument exception", ex.Message);
+            return new ObjectResult(ProblemDetailsFactory.CreateValidationProblemDetails(HttpContext, ModelState));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(500, ex, "Unexpected internal exception occurred during ServiceOwnerGetAuthorizedParties");
+            return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, detail: "Internal Server Error"));
+        }
+    }
+}

--- a/src/Altinn.AccessManagement/Mappers/AccessManagementMapper.cs
+++ b/src/Altinn.AccessManagement/Mappers/AccessManagementMapper.cs
@@ -39,6 +39,8 @@ namespace Altinn.AccessManagement.Mappers
                 .ForMember(dest => dest.Reference, act => act.MapFrom(src => src.Reference));
             CreateMap<AttributeMatch, AttributeMatchExternal>();
             CreateMap<AttributeMatchExternal, AttributeMatch>();
+            CreateMap<BaseAttribute, BaseAttributeExternal>();
+            CreateMap<BaseAttributeExternal, BaseAttribute>();
             CreateMap<PolicyAttributeMatch, PolicyAttributeMatchExternal>();
             CreateMap<PolicyAttributeMatchExternal, PolicyAttributeMatch>();
 

--- a/src/Altinn.AccessManagement/Models/AuthorizedPartyExternal.cs
+++ b/src/Altinn.AccessManagement/Models/AuthorizedPartyExternal.cs
@@ -63,11 +63,6 @@ public class AuthorizedPartyExternal
     public bool OnlyHierarchyElementWithNoAccess { get; set; }
 
     /// <summary>
-    /// Gets or sets the value of ChildParties
-    /// </summary>
-    public List<AuthorizedPartyExternal> ChildParties { get; set; } = [];
-
-    /// <summary>
     /// Gets or sets a collection of all resource identifier the authorized actor has been authorized with some right for, on behalf of this party
     /// </summary>
     public List<string> AuthorizedResources { get; set; } = [];
@@ -76,4 +71,9 @@ public class AuthorizedPartyExternal
     /// Gets or sets a collection of all rolecodes for roles from either Enhetsregisteret or Altinn 2 which the authorized actor has been authorized for, on behalf of this party
     /// </summary>
     public List<string> AuthorizedRoles { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the value of ChildParties
+    /// </summary>
+    public List<AuthorizedPartyExternal> ChildParties { get; set; } = [];
 }

--- a/src/Altinn.AccessManagement/Models/BaseAttributeExternal.cs
+++ b/src/Altinn.AccessManagement/Models/BaseAttributeExternal.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Altinn.AccessManagement.Models;
+
+/// <summary>
+/// This model describes a an Attribute consisting of an Attribute Type and Attribute Value which can also be represented as a Urn by combining the properties as '{type}:{value}'
+/// It's used both for external API input/output but also internally for working with attributes and matching to XACML-attributes used in policies, indentifying for instance a resource, a user, a party or an action.
+/// </summary>
+public class BaseAttributeExternal
+{
+    /// <summary>
+    /// Gets or sets the attribute id for the match
+    /// </summary>
+    [Required]
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the attribute value for the match
+    /// </summary>
+    [Required]
+    [JsonPropertyName("value")]
+    public string Value { get; set; }
+}

--- a/src/Altinn.AccessManagement/Program.cs
+++ b/src/Altinn.AccessManagement/Program.cs
@@ -291,6 +291,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         options.AddPolicy(AuthzConstants.POLICY_MASKINPORTEN_DELEGATIONS_PROXY, policy => policy.Requirements.Add(new ScopeAccessRequirement(new string[] { "altinn:maskinporten/delegations", "altinn:maskinporten/delegations.admin" })));
         options.AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ, policy => policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_access_management")));
         options.AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE, policy => policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_access_management")));
+        options.AddPolicy(AuthzConstants.POLICY_RESOURCEOWNER_AUTHORIZEDPARTIES, policy =>
+            policy.Requirements.Add(new ScopeAccessRequirement(new string[] { AuthzConstants.SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES, AuthzConstants.SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES_ADMIN })));
     });
 
     services.AddTransient<IAuthorizationHandler, ClaimAccessHandler>();

--- a/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
+++ b/src/Altinn.AccessManagement/Utilities/IdentifierUtil.cs
@@ -171,12 +171,12 @@ namespace Altinn.AccessManagement.Utilities
             {
                 if (!context.Request.Headers.ContainsKey(PersonHeader))
                 {
-                    throw new ArgumentException($"When using the '{PersonHeaderTrigger}' path parameter the social security number must be provided as a request header value: '{PersonHeader}'");
+                    throw new ArgumentException($"When using the '{PersonHeaderTrigger}' path parameter the national identity number must be provided as a request header value: '{PersonHeader}'");
                 }
 
                 if (!IsValidSSN(context.Request.Headers[PersonHeader]))
                 {
-                    throw new ArgumentException($"The request header '{PersonHeader}' does not provide a well-formed social security number value: '{context.Request.Headers[PersonHeader]}'");
+                    throw new ArgumentException($"The request header '{PersonHeader}' does not provide a well-formed national identity number value: '{context.Request.Headers[PersonHeader]}'");
                 }
 
                 return new AttributeMatch { Id = AltinnXacmlConstants.MatchAttributeIdentifiers.SocialSecurityNumberAttribute, Value = context.Request.Headers[PersonHeader] };

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_07124912037/to_27099450067/by_07124912037/success_request.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_07124912037/to_27099450067/by_07124912037/success_request.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_07124912037/to_27099450067/by_07124912037/success_response.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_07124912037/to_27099450067/by_07124912037/success_response.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/missing-to-lastname_request.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/missing-to-lastname_request.json
@@ -1,7 +1,7 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "02056260016"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/missing-to-lastname_response.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/missing-to-lastname_response.json
@@ -5,7 +5,7 @@
   "traceId": "00-28b6bcd340952ec6500b24cdc8498b6a-60b6ed58b49f5af6-00",
   "errors": {
     "To": [
-      "A distinct recipient party for the delegation, could not be identified by the supplied attributes. A recipient can be identified by either a single urn:altinn:organizationnumber or urn:altinn:enterpriseusername attribute, or a combination of urn:altinn:ssn and urn:altinn:lastname attributes, or urn:altinn:username and urn:altinn:lastname attributes."
+      "A distinct recipient party for the delegation, could not be identified by the supplied attributes. A recipient can be identified by either a single urn:altinn:organizationnumber or urn:altinn:enterpriseuser:username attribute, or a combination of urn:altinn:person:identifier-no and urn:altinn:person:lastname attributes, or urn:altinn:person:username and urn:altinn:person:lastname attributes."
     ]
   }
 }

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/success_request.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/success_request.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/success_response.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_07124912037/success_response.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_27099450067/success_request.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_27099450067/success_request.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_27099450067/success_response.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_27099450067/by_27099450067/success_response.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_OrstaECUser/by_02056260016/not-yet-supported_request.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_OrstaECUser/by_02056260016/not-yet-supported_request.json
@@ -1,7 +1,7 @@
 {
   "to": [
     {
-      "id": "urn:altinn:enterpriseusername",
+      "id": "urn:altinn:enterpriseuser:username",
       "value": "OrstaECUser"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_OrstaECUser/by_02056260016/success_request.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_OrstaECUser/by_02056260016/success_request.json
@@ -1,7 +1,7 @@
 {
   "to": [
     {
-      "id": "urn:altinn:enterpriseusername",
+      "id": "urn:altinn:enterpriseuser:username",
       "value": "OrstaECUser"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_OrstaECUser/by_02056260016/success_response.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/generic-access-resource/from_910459880/to_OrstaECUser/by_02056260016/success_response.json
@@ -1,7 +1,7 @@
 {
   "to": [
     {
-      "id": "urn:altinn:enterpriseusername",
+      "id": "urn:altinn:enterpriseuser:username",
       "value": "OrstaECUser"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/se_2802_2203/from_910459880/to_27099450067/by_07124912037/success_request.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/se_2802_2203/from_910459880/to_27099450067/by_07124912037/success_request.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/se_2802_2203/from_910459880/to_27099450067/by_07124912037/success_response.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/RightsDelegation/se_2802_2203/from_910459880/to_27099450067/by_07124912037/success_response.json
@@ -1,11 +1,11 @@
 {
   "to": [
     {
-      "id": "urn:altinn:ssn",
+      "id": "urn:altinn:person:identifier-no",
       "value": "27099450067"
     },
     {
-      "id": "urn:altinn:lastname",
+      "id": "urn:altinn:person:lastname",
       "value": "RAVNÅS"
     }
   ],

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAccessManager/KasperForSelf.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAccessManager/KasperForSelf.bru
@@ -1,11 +1,11 @@
 meta {
-  name: Paula
+  name: KasperForSelf
   type: http
-  seq: 2
+  seq: 1
 }
 
 get {
-  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=true
+  url: {{baseUrl}}/accessmanagement/api/v1/{{party}}/authorizedparties?includeAltinn2=true
   body: json
   auth: none
 }
@@ -21,9 +21,10 @@ headers {
 
 vars:pre-request {
   auth_tokenType: Personal
-  auth_userId: 20000095
-  auth_partyId: 50002203
-  auth_ssn: '02056260016'
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50002598
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAccessManager/KasperForØrsta.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAccessManager/KasperForØrsta.bru
@@ -1,0 +1,38 @@
+meta {
+  name: KasperForØrsta
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/{{party}}/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50005545
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Amund.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Amund.bru
@@ -1,17 +1,17 @@
 meta {
-  name: Asle
+  name: Amund
   type: http
-  seq: 4
+  seq: 2
 }
 
 get {
-  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=false
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=true
   body: json
   auth: none
 }
 
 query {
-  includeAltinn2: false
+  includeAltinn2: true
 }
 
 headers {
@@ -21,9 +21,9 @@ headers {
 
 vars:pre-request {
   auth_tokenType: Personal
-  auth_userId: 20001121
-  auth_partyId: 50003229
-  auth_ssn: '17105431031'
+  auth_userId: 20000071
+  auth_partyId: 50002179
+  auth_ssn: '01114270071'
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Asle.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Asle.bru
@@ -1,17 +1,17 @@
 meta {
-  name: Amund
+  name: Asle
   type: http
-  seq: 4
+  seq: 3
 }
 
 get {
-  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=true
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=false
   body: json
   auth: none
 }
 
 query {
-  includeAltinn2: true
+  includeAltinn2: false
 }
 
 headers {
@@ -21,9 +21,9 @@ headers {
 
 vars:pre-request {
   auth_tokenType: Personal
-  auth_userId: 20000071
-  auth_partyId: 50002179
-  auth_ssn: '01114270071'
+  auth_userId: 20001121
+  auth_partyId: 50003229
+  auth_ssn: '17105431031'
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Paula.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Paula.bru
@@ -1,17 +1,17 @@
 meta {
-  name: Kasper
+  name: Paula
   type: http
   seq: 1
 }
 
 get {
-  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=false
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=true
   body: json
   auth: none
 }
 
 query {
-  includeAltinn2: false
+  includeAltinn2: true
 }
 
 headers {
@@ -21,9 +21,9 @@ headers {
 
 vars:pre-request {
   auth_tokenType: Personal
-  auth_userId: 20000490
-  auth_partyId: 50002598
-  auth_ssn: '07124912037'
+  auth_userId: 20000095
+  auth_partyId: 50002203
+  auth_ssn: '02056260016'
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByNationalIdentity.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByNationalIdentity.bru
@@ -1,0 +1,44 @@
+meta {
+  name: KasperByNationalIdentity
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:person:identifier-no",
+    "value": "07124912037"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByPartyId.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByPartyId.bru
@@ -1,0 +1,44 @@
+meta {
+  name: KasperByPartyId
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:partyid",
+    "value": "50002598"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByUserId.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByUserId.bru
@@ -1,0 +1,44 @@
+meta {
+  name: KasperByUserId
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:userid",
+    "value": "20000490"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByUuid.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByUuid.bru
@@ -1,0 +1,44 @@
+meta {
+  name: KasperByUuid
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:person:uuid",
+    "value": "ee007db6-0db4-4e55-ac21-2a888f04d846"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUsername.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUsername.bru
@@ -1,0 +1,44 @@
+meta {
+  name: OrstaECUserByUsername
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:enterpriseuser:username",
+    "value": "OrstaECUser"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUuid.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUuid.bru
@@ -1,0 +1,44 @@
+meta {
+  name: OrstaECUserByUuid
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:enterpriseuser:uuid",
+    "value": "002209f9-57fc-4d7c-9a60-ef0ab8e4eb06"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByOrgNo.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByOrgNo.bru
@@ -1,0 +1,44 @@
+meta {
+  name: ØrstaByOrgNo
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:organization:identifier-no",
+    "value": "910459880"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByPartyId.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByPartyId.bru
@@ -1,0 +1,44 @@
+meta {
+  name: ØrstaByPartyId
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:partyid",
+    "value": "50005545"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByUuid.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByUuid.bru
@@ -1,0 +1,44 @@
+meta {
+  name: ØrstaByUuid
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:organization:uuid",
+    "value": "ff6fbedd-95ef-4de2-aed3-e6aeb292bd50"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Enterprise
+  auth_org: digdir
+  auth_orgNo: 991825827
+  auth_scopes: altinn:resourceowner/authorizedparties
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetSelf.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetSelf.bru
@@ -1,0 +1,38 @@
+meta {
+  name: KasperGetSelf
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparty/{{partyId}}?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  partyId: 50002598
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetØrsta.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetØrsta.bru
@@ -1,0 +1,38 @@
+meta {
+  name: KasperGetØrsta
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparty/{{partyId}}?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  partyId: 50005545
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}


### PR DESCRIPTION
## Description
As authenticated user:
- Added API endpoint for getting a single authorized party from the authenticated users list of authorized parties, if it exists in the list 'GET authorizedparty/{partyId}'

As Access Manager for {party}:
- Added API endpoint for getting the list of authorized parties for a given {party}, when the authenticated user is authorized as Access Manager for the {party} 'GET {party}/authorizedparties'

As Resource Owner:
- Added API endpoint for getting the list of authorized parties for any third party in Altinn, when authorized as a Resource Owner with one of the following Maskinporten scopes: 'altinn:resourceowner/authorizedparties' or 'altinn:resourceowner/authorizedparties.admin'

## Related Issue(s)
- #563

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
