### PR TITLE
Bugfix/632 change party type enum back

### DIFF
--- a/src/Altinn.AccessManagement/Models/PartyExternal.cs
+++ b/src/Altinn.AccessManagement/Models/PartyExternal.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Altinn.AccessManagement.Enums;
+using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 
 namespace Altinn.AccessManagement.Models
@@ -18,7 +19,7 @@ namespace Altinn.AccessManagement.Models
         /// <summary>
         /// Gets or sets the type of party
         /// </summary>
-        public AuthorizedPartyTypeExternal PartyTypeName { get; set; }
+        public PartyType PartyTypeName { get; set; }
 
         /// <summary>
         /// Gets the parties org number

--- a/test/Altinn.AccessManagement.Tests/Utils/TestDataUtil.cs
+++ b/test/Altinn.AccessManagement.Tests/Utils/TestDataUtil.cs
@@ -514,7 +514,7 @@ namespace Altinn.AccessManagement.Tests.Utils
             PartyExternal partyExternal = new PartyExternal
             {
                 PartyId = party.PartyId,
-                PartyTypeName = (Enums.AuthorizedPartyTypeExternal)party.PartyTypeName,
+                PartyTypeName = party.PartyTypeName,
                 OrgNumber = party.OrgNumber,
                 SSN = party.SSN,
                 UnitType = party.UnitType,


### PR DESCRIPTION
## Description
The enum was changed in error to the new AuthorizedPartyTypeExternal enum as part of change
PR https://github.com/Altinn/altinn-access-management/pull/595

## Related Issue(s)
- #632 

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
