### PR TITLE
Hotfix for bug with AddSqlTags in Persistence

### DIFF
--- a/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepository.cs
+++ b/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepository.cs
@@ -81,7 +81,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_coveredByPartyId", coveredByPartyId.HasValue ? coveredByPartyId.Value : DBNull.Value);
 
             List<DelegationChange> delegationChanges = new List<DelegationChange>();
-            activity.AddSqlTags(pgcom);
 
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
             while (reader.Read())
@@ -156,8 +155,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_resourceRegistryIds", NpgsqlDbType.Array | NpgsqlDbType.Text, (resourceRegistryIds == null || !resourceRegistryIds.Any()) ? DBNull.Value : resourceRegistryIds);
             pgcom.Parameters.AddWithValue("_resourceTypes", NpgsqlDbType.Array | NpgsqlDbType.Text, (resourceTypes == null || !resourceTypes.Any()) ? DBNull.Value : resourceTypes.Select(rt => rt.ToString().ToLower()).ToList());
 
-            activity.AddSqlTags(pgcom);
-
             List<DelegationChange> delegatedResources = new List<DelegationChange>();
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
             while (reader.Read())
@@ -188,8 +185,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_resourceRegistryIds", NpgsqlDbType.Array | NpgsqlDbType.Text, (resourceRegistryIds == null || !resourceRegistryIds.Any()) ? DBNull.Value : resourceRegistryIds);
             pgcom.Parameters.AddWithValue("_resourceTypes", NpgsqlDbType.Array | NpgsqlDbType.Text, (resourceTypes == null || !resourceTypes.Any()) ? DBNull.Value : resourceTypes.Select(rt => rt.ToString().ToLower()).ToList());
 
-            activity.AddSqlTags(pgcom);
-
             List<DelegationChange> receivedDelegations = new List<DelegationChange>();
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
             while (reader.Read())
@@ -219,8 +214,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_offeredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, (offeredByPartyIds == null || !offeredByPartyIds.Any()) ? DBNull.Value : offeredByPartyIds);
             pgcom.Parameters.AddWithValue("_resourceRegistryIds", NpgsqlDbType.Array | NpgsqlDbType.Text, (resourceRegistryIds == null || !resourceRegistryIds.Any()) ? DBNull.Value : resourceRegistryIds);
             pgcom.Parameters.AddWithValue("_resourceTypes", NpgsqlDbType.Array | NpgsqlDbType.Text, (resourceTypes == null || !resourceTypes.Any()) ? DBNull.Value : resourceTypes.Select(rt => rt.ToString().ToLower()).ToList());
-
-            activity.AddSqlTags(pgcom);
 
             List<DelegationChange> receivedDelegations = new List<DelegationChange>();
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
@@ -313,7 +306,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             await using var pgcom = _conn.CreateCommand(QUERY);
             pgcom.Parameters.AddWithNullableValue("offeredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, offeredByPartyIds);
 
-            activity.AddSqlTags(pgcom);
             return await pgcom.ExecuteEnumerableAsync(cancellationToken)
                 .SelectAwait(GetDelegationChange)
                 .ToListAsync(cancellationToken);
@@ -409,7 +401,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithNullableValue("coveredByUserIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, coveredByUserIds);
             pgcom.Parameters.AddWithNullableValue("coveredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, coveredByPartyIds);
 
-            activity.AddSqlTags(pgcom);
             return await pgcom.ExecuteEnumerableAsync(cancellationToken)
                 .SelectAwait(GetDelegationChange)
                 .ToListAsync(cancellationToken);
@@ -437,7 +428,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_blobStoragePolicyPath", delegationChange.BlobStoragePolicyPath);
             pgcom.Parameters.AddWithValue("_blobStorageVersionId", delegationChange.BlobStorageVersionId);
 
-            activity.AddSqlTags(pgcom);
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
             if (reader.Read())
             {
@@ -471,7 +461,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_blobStorageVersionId", delegationChange.BlobStorageVersionId);
             pgcom.Parameters.AddWithValue("_delegatedTime", delegationChange.Created.HasValue ? delegationChange.Created.Value : DateTime.UtcNow);
 
-            activity.AddSqlTags(pgcom);
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
             if (reader.Read())
             {
@@ -500,7 +489,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_coveredByUserId", coveredByUserId.HasValue ? coveredByUserId.Value : DBNull.Value);
             pgcom.Parameters.AddWithValue("_coveredByPartyId", coveredByPartyId.HasValue ? coveredByPartyId.Value : DBNull.Value);
 
-            activity.AddSqlTags(pgcom);
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
             if (reader.Read())
             {
@@ -528,7 +516,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_coveredByUserId", coveredByUserId.HasValue ? coveredByUserId.Value : DBNull.Value);
             pgcom.Parameters.AddWithValue("_coveredByPartyId", coveredByPartyId.HasValue ? coveredByPartyId.Value : DBNull.Value);
 
-            activity.AddSqlTags(pgcom);
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
             if (reader.Read())
             {
@@ -557,7 +544,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_resourceRegistryIds", NpgsqlDbType.Array | NpgsqlDbType.Text, resourceIds);
             pgcom.Parameters.AddWithValue("_resourceTypes", NpgsqlDbType.Array | NpgsqlDbType.Text, new List<string> { resourceType.ToString().ToLower() });
 
-            activity.AddSqlTags(pgcom);
             List<DelegationChange> receivedDelegations = new List<DelegationChange>();
             
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
@@ -661,7 +647,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_offeredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, offeredByPartyIds);
             pgcom.Parameters.AddWithValue("_coveredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, coveredByPartyIds);
 
-            activity.AddSqlTags(pgcom);
             List<DelegationChange> delegationChanges = new List<DelegationChange>();
 
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
@@ -691,7 +676,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_offeredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, offeredByPartyIds);
             pgcom.Parameters.AddWithValue("_coveredByUserIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, coveredByUserIds);
 
-            activity.AddSqlTags(pgcom);
             List<DelegationChange> delegationChanges = new List<DelegationChange>();
 
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
@@ -720,7 +704,6 @@ public class DelegationMetadataRepository : IDelegationMetadataRepository
             pgcom.Parameters.AddWithValue("_altinnAppIds", NpgsqlDbType.Array | NpgsqlDbType.Text, altinnAppIds?.Count > 0 ? altinnAppIds : DBNull.Value);
             pgcom.Parameters.AddWithValue("_offeredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, offeredByPartyIds);
 
-            activity.AddSqlTags(pgcom);
             List<DelegationChange> delegationChanges = new List<DelegationChange>();
 
             using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();

--- a/src/Altinn.AccessManagement.Persistence/Extensions/ActivityExtensions.cs
+++ b/src/Altinn.AccessManagement.Persistence/Extensions/ActivityExtensions.cs
@@ -19,31 +19,30 @@ public static class ActivityExtensions
     /// <param name="command">NpgsqlCommand</param>
     public static void AddSqlTags(this Activity activity, NpgsqlCommand command)
     {
-        activity.SetTag("db.system", "Postgres");
-        activity.SetTag("db.statement", command.CommandText);
-
-        foreach (var param in command.Parameters.ToList())
+        try
         {
-            try
+            activity.SetTag("db.system", "Postgres");
+            activity.SetTag("db.statement", command.CommandText);
+            foreach (var param in command.Parameters.ToList())
             {
-                if (param.Value == null) 
-                { 
-                    continue; 
-                }
+                    if (param.Value == null) 
+                    { 
+                        continue; 
+                    }
 
-                if (param.Value is IList)
-                {
-                    activity.SetTag(param.ParameterName, string.Join(',', (IList)param.Value));
-                }
-                else
-                {
-                    activity.SetTag(param.ParameterName, param.Value);
-                }
+                    if (param.Value is IList)
+                    {
+                        activity.SetTag(param.ParameterName, string.Join(',', (IList)param.Value));
+                    }
+                    else
+                    {
+                        activity.SetTag(param.ParameterName, param.Value);
+                    }
             }
-            catch (Exception ex) 
-            { 
-                activity.RecordException(ex);
-            }
+        }
+        catch (Exception ex) 
+        { 
+            activity.RecordException(ex);
         }
     }
 

--- a/src/Altinn.AccessManagement.Persistence/Extensions/ActivityExtensions.cs
+++ b/src/Altinn.AccessManagement.Persistence/Extensions/ActivityExtensions.cs
@@ -13,49 +13,15 @@ namespace Altinn.AccessManagement.Persistence.Extensions;
 public static class ActivityExtensions
 {
     /// <summary>
-    /// Sets Activity tags based on command
-    /// </summary>
-    /// <param name="activity">Current activity</param>
-    /// <param name="command">NpgsqlCommand</param>
-    public static void AddSqlTags(this Activity activity, NpgsqlCommand command)
-    {
-        try
-        {
-            activity.SetTag("db.system", "Postgres");
-            activity.SetTag("db.statement", command.CommandText);
-            foreach (var param in command.Parameters.ToList())
-            {
-                    if (param.Value == null) 
-                    { 
-                        continue; 
-                    }
-
-                    if (param.Value is IList)
-                    {
-                        activity.SetTag(param.ParameterName, string.Join(',', (IList)param.Value));
-                    }
-                    else
-                    {
-                        activity.SetTag(param.ParameterName, param.Value);
-                    }
-            }
-        }
-        catch (Exception ex) 
-        { 
-            activity.RecordException(ex);
-        }
-    }
-
-    /// <summary>
     /// Sets status and records exception
     /// </summary>
     /// <param name="activity">Current activity</param>
     /// <param name="ex">Exception to record</param>
     /// <param name="statusDescription">Optional description/message for error</param>
-    public static void ErrorWithException(this Activity activity, Exception ex, string? statusDescription = null)
+    public static void ErrorWithException(this Activity? activity, Exception ex, string? statusDescription = null)
     {
-        activity.RecordException(ex);
-        activity.SetStatus(ActivityStatusCode.Error, statusDescription);
+        activity?.RecordException(ex);
+        activity?.SetStatus(ActivityStatusCode.Error, statusDescription);
     }
 
     /// <summary>
@@ -64,13 +30,13 @@ public static class ActivityExtensions
     /// <param name="activity">Current activity</param>
     /// <param name="statusDescription">Optional description/message for error</param>
     /// <param name="resultSize">Optional metric of resultsize</param>
-    public static void FinishedOk(this Activity activity, string? statusDescription = null, int? resultSize = null)
+    public static void FinishedOk(this Activity? activity, string? statusDescription = null, int? resultSize = null)
     {
         if (resultSize != null) 
         {
-            activity.SetTag("ResultSize", resultSize.Value);
+            activity?.SetTag("ResultSize", resultSize.Value);
         }
 
-        activity.SetStatus(ActivityStatusCode.Ok, statusDescription);
+        activity?.SetStatus(ActivityStatusCode.Ok, statusDescription);
     }
 }

--- a/src/Altinn.AccessManagement.Persistence/ResourceMetadataRepository.cs
+++ b/src/Altinn.AccessManagement.Persistence/ResourceMetadataRepository.cs
@@ -46,8 +46,6 @@ namespace Altinn.AccessManagement.Persistence
                 pgcom.Parameters.AddWithValue("_resourceregistryid", resource.ResourceRegistryId);
                 pgcom.Parameters.AddWithValue("_resourcetype", NpgsqlTypes.NpgsqlDbType.Text, resource.ResourceType.ToString().ToLower());
 
-                activity.AddSqlTags(pgcom);
-
                 using NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync();
                 if (reader.Read())
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hotfix for bug with AddSqlTags in Persistence

System.NullReferenceException: Object reference not set to an instance of an object.
   at Altinn.AccessManagement.Persistence.Extensions.ActivityExtensions.AddSqlTags(Activity activity, NpgsqlCommand command) in /app/src/Altinn.AccessManagement.Persistence/Extensions/ActivityExtensions.cs:line 22

## Related Issue(s)
- #{insert issue number here}

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
