### PR TITLE
Fix Revoke support for both UserId and PartyId as From and To attributes

### DIFF
--- a/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
+++ b/src/Altinn.AccessManagement.Core/Asserters/AttributeMatchAsserter.cs
@@ -163,6 +163,20 @@ public static class AttributeMatchAsserter
             assert.AttributesAreIntegers(Urn.InternalIds))(errors, values);
 
     /// <summary>
+    /// A list of assertions for validating input is a single value of either of the internal Altinn 2 identifiers: UserId or PartyId.
+    /// </summary>
+    /// <param name="assert">list of assertions</param>
+    /// <param name="errors">dictionary for writing assertion errors</param>
+    /// <param name="values">list of attributes</param>
+    public static void Altinn2InternalIds(this IAssert<AttributeMatch> assert, IDictionary<string, string[]> errors, IEnumerable<AttributeMatch> values) =>
+        assert.All(
+            assert.Single(
+                assert.HasAttributeTypes(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute),
+                assert.HasAttributeTypes(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute)),
+            assert.AllAttributesHasValues,
+            assert.AttributesAreIntegers(Urn.Altinn2InternalIds))(errors, values);
+
+    /// <summary>
     /// A default list of assertions that contains the baseline for validating input for a resource.
     /// </summary>
     /// <param name="assert">list of assertions</param>

--- a/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
+++ b/src/Altinn.AccessManagement.Core/Helpers/DelegationHelper.cs
@@ -491,14 +491,10 @@ namespace Altinn.AccessManagement.Core.Helpers
         }
 
         /// <summary>
-        /// Builds a RequestToDelete request model for revoking all delegated rules for a resource registry service
+        /// Builds a RequestToDelete request model for revoking all delegated rules for the resource if delegated between the from and to parties
         /// </summary>
-        public static List<RequestToDelete> GetRequestToDeleteResource(int authenticatedUserId, IEnumerable<AttributeMatch> resource, int fromPartyId, IEnumerable<AttributeMatch> to)
+        public static List<RequestToDelete> GetRequestToDeleteResource(int authenticatedUserId, IEnumerable<AttributeMatch> resource, int fromPartyId, AttributeMatch to)
         {
-            var coveredBy = to.Any(p => p.Id == Urn.Altinn.Person.UserId || p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute) 
-                ? new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, to.First(p => p.Id == Urn.Altinn.Person.UserId || p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute).Value) 
-                : new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, to.First(p => p.Id == Urn.Altinn.Organization.PartyId).Value);
-
             return new List<RequestToDelete>
             {
                 new RequestToDelete
@@ -507,7 +503,7 @@ namespace Altinn.AccessManagement.Core.Helpers
                     PolicyMatch = new PolicyMatch
                     {
                         OfferedByPartyId = fromPartyId,
-                        CoveredBy = coveredBy.SingleToList(),
+                        CoveredBy = to.SingleToList(),
                         Resource = resource.ToList()
                     }
                 }

--- a/src/Altinn.AccessManagement.Core/Resolvers/Altinn/AltinnResolver.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Altinn/AltinnResolver.cs
@@ -5,7 +5,7 @@ namespace Altinn.AccessManagement.Core.Resolvers;
 /// <summary>
 /// Resolves attributes for <see cref="Urn.Altinn"/> 
 /// </summary>
-public class AltinnResolver(AltinnPersonResolver person, AltinnOrganizationResolver organization, AltinnResourceResolver resource, AltinnEnterpriseUserResolver enterpriseUserResolver)
-    : AttributeResolver(Urn.Altinn.String(), person, organization, resource, enterpriseUserResolver)
+public class AltinnResolver(AltinnResourceResolver resource, PartyAttributeResolver partyAttributeResolver, UserAttributeResolver userAttributeResolver)
+    : AttributeResolver(Urn.Altinn.String(), resource, partyAttributeResolver, userAttributeResolver)
 {
 }

--- a/src/Altinn.AccessManagement.Core/Resolvers/Altinn/AltinnResolver.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Altinn/AltinnResolver.cs
@@ -5,7 +5,7 @@ namespace Altinn.AccessManagement.Core.Resolvers;
 /// <summary>
 /// Resolves attributes for <see cref="Urn.Altinn"/> 
 /// </summary>
-public class AltinnResolver(AltinnResourceResolver resource, PartyAttributeResolver partyAttributeResolver, UserAttributeResolver userAttributeResolver)
-    : AttributeResolver(Urn.Altinn.String(), resource, partyAttributeResolver, userAttributeResolver)
+public class AltinnResolver(AltinnResourceResolver resource, PartyAttributeResolver partyAttributeResolver, UserAttributeResolver userAttributeResolver, AltinnPersonResolver personResolver, AltinnOrganizationResolver organizationResolver)
+    : AttributeResolver(Urn.Altinn.String(), resource, partyAttributeResolver, userAttributeResolver, personResolver, organizationResolver)
 {
 }

--- a/src/Altinn.AccessManagement.Core/Resolvers/Altinn/PartyAttributeResolver.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Altinn/PartyAttributeResolver.cs
@@ -1,0 +1,62 @@
+using Altinn.AccessManagement.Core.Clients.Interfaces;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Resolvers;
+using Altinn.AccessManagement.Core.Resolvers.Extensions;
+using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.Platform.Profile.Models;
+
+namespace Altinn.AccessManagement.Resolvers;
+
+/// <summary>
+/// Resolves Party attribute as a PartyId
+/// </summary>
+public class PartyAttributeResolver : AttributeResolver
+{
+    private readonly IContextRetrievalService _contextRetrievalService;
+    private readonly IProfileClient _profile;
+
+    /// <summary>
+    /// Resolves Party attribute as a PartyId
+    /// </summary>
+    /// <param name="contextRetrievalService">service init</param>
+    /// <param name="profile">profile client</param>
+    public PartyAttributeResolver(IContextRetrievalService contextRetrievalService, IProfileClient profile) : base(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute)
+    {
+        AddLeaf([AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute], [AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute], ResolvePartyIdFromParty());
+        AddLeaf([AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute], [AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute], ResolvePartyIdFromUser());
+
+        _contextRetrievalService = contextRetrievalService;
+        _profile = profile;
+    }
+
+    /// <summary>
+    /// Resolves a PartyId if given <see cref="AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute"/> exists
+    /// </summary>
+    public LeafResolver ResolvePartyIdFromUser() => async (attributes, cancellationToken) =>
+    {
+        UserProfile user = await _profile.GetUser(new()
+        {
+            UserId = attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute)
+        });
+
+        if (user != null)
+        {
+            return [new(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, user.Party.PartyId)];
+        }
+
+        return [];
+    };
+
+    /// <summary>
+    /// Resolves a PartyId if given <see cref="AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute"/> exists
+    /// </summary>
+    public LeafResolver ResolvePartyIdFromParty() => async (attributes, cancellationToken) =>
+    {
+        if (await _contextRetrievalService.GetPartyAsync(attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute)) is var party && party != null)
+        {
+            return [new(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, party.PartyId)];
+        }
+
+        return [];
+    };
+}

--- a/src/Altinn.AccessManagement.Core/Resolvers/Altinn/PartyAttributeResolver.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Altinn/PartyAttributeResolver.cs
@@ -34,10 +34,9 @@ public class PartyAttributeResolver : AttributeResolver
     /// </summary>
     public LeafResolver ResolvePartyIdFromUser() => async (attributes, cancellationToken) =>
     {
-        UserProfile user = await _profile.GetUser(new()
-        {
-            UserId = attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute)
-        });
+        UserProfile user = await _profile.GetUser(
+            new() { UserId = attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute) },
+            cancellationToken);
 
         if (user != null)
         {
@@ -52,7 +51,7 @@ public class PartyAttributeResolver : AttributeResolver
     /// </summary>
     public LeafResolver ResolvePartyIdFromParty() => async (attributes, cancellationToken) =>
     {
-        if (await _contextRetrievalService.GetPartyAsync(attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute)) is var party && party != null)
+        if (await _contextRetrievalService.GetPartyAsync(attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute), cancellationToken) is var party && party != null)
         {
             return [new(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, party.PartyId)];
         }

--- a/src/Altinn.AccessManagement.Core/Resolvers/Altinn/UserAttributeResolver.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Altinn/UserAttributeResolver.cs
@@ -34,10 +34,9 @@ public class UserAttributeResolver : AttributeResolver
     /// </summary>
     public LeafResolver ResolveFromUser() => async (attributes, cancellationToken) =>
     {
-        UserProfile user = await _profile.GetUser(new()
-        {
-            UserId = attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute)
-        });
+        UserProfile user = await _profile.GetUser(
+            new() { UserId = attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute) },
+            cancellationToken);
 
         if (user != null)
         {
@@ -52,12 +51,9 @@ public class UserAttributeResolver : AttributeResolver
     /// </summary>
     public LeafResolver ResolveFromParty() => async (attributes, cancellationToken) =>
     {
-        if (await _contextRetrievalService.GetPartyAsync(attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute)) is var party && party != null)
+        if (await _contextRetrievalService.GetPartyAsync(attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute), cancellationToken) is var party && party?.Person != null)
         {
-            if (party.Person != null)
-            {
-                return await ResolveUserIdUsingIdentifierNo()([new(Urn.Altinn.Person.IdentifierNo, party.Person.SSN)], cancellationToken);
-            }
+            return await ResolveUserIdUsingIdentifierNo()([new(Urn.Altinn.Person.IdentifierNo, party.Person.SSN)], cancellationToken);
         }
 
         return [];
@@ -68,10 +64,9 @@ public class UserAttributeResolver : AttributeResolver
     /// </summary>
     public LeafResolver ResolveUserIdUsingIdentifierNo() => async (attributes, cancellationToken) =>
     {
-        var user = await _profile.GetUser(new()
-        {
-            Ssn = attributes.GetRequiredString(Urn.Altinn.Person.IdentifierNo)
-        });
+        var user = await _profile.GetUser(
+            new() { Ssn = attributes.GetRequiredString(Urn.Altinn.Person.IdentifierNo) },
+            cancellationToken);
 
         if (user != null)
         {

--- a/src/Altinn.AccessManagement.Core/Resolvers/Altinn/UserAttributeResolver.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Altinn/UserAttributeResolver.cs
@@ -1,0 +1,86 @@
+using Altinn.AccessManagement.Core.Clients.Interfaces;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Resolvers;
+using Altinn.AccessManagement.Core.Resolvers.Extensions;
+using Altinn.AccessManagement.Core.Services.Interfaces;
+using Altinn.Platform.Profile.Models;
+
+namespace Altinn.AccessManagement.Resolvers;
+
+/// <summary>
+/// Resolves From attribute as a PartyId
+/// </summary>
+public class UserAttributeResolver : AttributeResolver
+{
+    private readonly IContextRetrievalService _contextRetrievalService;
+    private readonly IProfileClient _profile;
+
+    /// <summary>
+    /// Resolves To attribute as a either a PartyId (if found as an organization) or a UserId (if found as a user)
+    /// </summary>
+    /// <param name="contextRetrievalService">service init</param>
+    /// <param name="profile">profile client</param>
+    public UserAttributeResolver(IContextRetrievalService contextRetrievalService, IProfileClient profile) : base(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute)
+    {
+        AddLeaf([AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute], [AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute], ResolveFromParty());
+        AddLeaf([AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute], [AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute], ResolveFromUser());
+
+        _contextRetrievalService = contextRetrievalService;
+        _profile = profile;
+    }
+
+    /// <summary>
+    /// Resolves a UserId if given <see cref="AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute"/> exists
+    /// </summary>
+    public LeafResolver ResolveFromUser() => async (attributes, cancellationToken) =>
+    {
+        UserProfile user = await _profile.GetUser(new()
+        {
+            UserId = attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute)
+        });
+
+        if (user != null)
+        {
+            return [new(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, user.UserId)];
+        }
+
+        return [];
+    };
+
+    /// <summary>
+    /// Resolves a party if given a <see cref="AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute"/>
+    /// </summary>
+    public LeafResolver ResolveFromParty() => async (attributes, cancellationToken) =>
+    {
+        if (await _contextRetrievalService.GetPartyAsync(attributes.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute)) is var party && party != null)
+        {
+            if (party.Person != null)
+            {
+                return await ResolveUserIdUsingIdentifierNo()([new(Urn.Altinn.Person.IdentifierNo, party.Person.SSN)], cancellationToken);
+            }
+        }
+
+        return [];
+    };
+
+    /// <summary>
+    /// Resolves a person to a userId
+    /// </summary>
+    public LeafResolver ResolveUserIdUsingIdentifierNo() => async (attributes, cancellationToken) =>
+    {
+        var user = await _profile.GetUser(new()
+        {
+            Ssn = attributes.GetRequiredString(Urn.Altinn.Person.IdentifierNo)
+        });
+
+        if (user != null)
+        {
+            return
+            [
+                new(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, user.UserId)
+            ];
+        }
+
+        return [];
+    };
+}

--- a/src/Altinn.AccessManagement.Core/Resolvers/Extensions/ResolverExtensions.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Extensions/ResolverExtensions.cs
@@ -23,6 +23,8 @@ public static class ResolverExtensions
         services.AddTransient<AltinnResourceResolver>();
         services.AddTransient<AltinnOrganizationResolver>();
         services.AddTransient<AltinnPersonResolver>();
+        services.AddTransient<PartyAttributeResolver>();
+        services.AddTransient<UserAttributeResolver>();
         return services;
     }
 

--- a/src/Altinn.AccessManagement.Core/Resolvers/Urn.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Urn.cs
@@ -16,7 +16,7 @@ public static class Urn
     /// <summary>
     /// InternalIds of delegatable entities 
     /// </summary>
-    public static string[] InternalIds => [AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute];
+    public static string[] InternalIds => [Altinn.Organization.PartyId, Altinn.Person.PartyId, Altinn.Person.UserId, Altinn.EnterpriseUser.UserId, AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute];
 
     /// <summary>
     /// InternalIds from Altinn 2

--- a/src/Altinn.AccessManagement.Core/Resolvers/Urn.cs
+++ b/src/Altinn.AccessManagement.Core/Resolvers/Urn.cs
@@ -16,7 +16,12 @@ public static class Urn
     /// <summary>
     /// InternalIds of delegatable entities 
     /// </summary>
-    public static string[] InternalIds => [Altinn.Organization.PartyId, Altinn.Person.PartyId, Altinn.Person.UserId, Altinn.EnterpriseUser.UserId, AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute];
+    public static string[] InternalIds => [AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute];
+
+    /// <summary>
+    /// InternalIds from Altinn 2
+    /// </summary>
+    public static string[] Altinn2InternalIds => [AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute];
 
     /// <summary>
     /// Resources that belongs to Altinn 

--- a/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
@@ -186,7 +186,7 @@ namespace Altinn.AccessManagement.Core.Services
                 ? new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, toAttribute.First(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute).Value)
                 : new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, toAttribute.First(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute).Value);
 
-            var policiesToDelete = DelegationHelper.GetRequestToDeleteResource(authenticatedUserId, delegation.Rights.First().Resource, fromAttribute.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute), to);
+            var policiesToDelete = DelegationHelper.GetRequestToDeleteResource(authenticatedUserId, delegation.Rights[0].Resource, fromAttribute.GetRequiredInt(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute), to);
 
             await _pap.TryDeleteDelegationPolicies(policiesToDelete);
             return assertion;

--- a/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/SingleRightsService.cs
@@ -180,7 +180,7 @@ namespace Altinn.AccessManagement.Core.Services
             }
             
             var fromAttribute = await _resolver.Resolve(delegation.From, [AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute], cancellationToken);
-            var toAttribute = await _resolver.Resolve(delegation.To, Urn.InternalIds, cancellationToken);
+            var toAttribute = await _resolver.Resolve(delegation.To, Urn.Altinn2InternalIds, cancellationToken);
 
             var to = toAttribute.Any(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute)
                 ? new AttributeMatch(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, toAttribute.First(p => p.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute).Value)

--- a/src/Altinn.AccessManagement/Controllers/RightsInternalController.cs
+++ b/src/Altinn.AccessManagement/Controllers/RightsInternalController.cs
@@ -300,15 +300,6 @@ namespace Altinn.AccessManagement.Controllers
                 int authenticatedUserId = AuthenticationHelper.GetUserId(HttpContext);
                 AttributeMatch reportee = IdentifierUtil.GetIdentifierAsAttributeMatch(input.Party, HttpContext);
                 var delegation = _mapper.Map<DelegationLookup>(body);
-                if (reportee.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationNumberAttribute)
-                {
-                    reportee.Id = Urn.Altinn.Organization.IdentifierNo;
-                }
-
-                if (reportee.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.SocialSecurityNumberAttribute)
-                {
-                    reportee.Id = Urn.Altinn.Person.IdentifierNo;
-                }
 
                 delegation.To = reportee.SingleToList();
 
@@ -366,15 +357,6 @@ namespace Altinn.AccessManagement.Controllers
                 int authenticatedUserId = AuthenticationHelper.GetUserId(HttpContext);
                 AttributeMatch reportee = IdentifierUtil.GetIdentifierAsAttributeMatch(input.Party, HttpContext);
                 var delegation = _mapper.Map<DelegationLookup>(body);
-                if (reportee.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationNumberAttribute)
-                {
-                    reportee.Id = Urn.Altinn.Organization.IdentifierNo;
-                }
-
-                if (reportee.Id == AltinnXacmlConstants.MatchAttributeIdentifiers.SocialSecurityNumberAttribute)
-                {
-                    reportee.Id = Urn.Altinn.Person.IdentifierNo;
-                }
 
                 delegation.From = reportee.SingleToList();
                 var result = await _rights.RevokeRightsDelegation(authenticatedUserId, delegation, cancellationToken);

--- a/test/Altinn.AccessManagement.Tests/Controllers/RightsInternalControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/RightsInternalControllerTest.cs
@@ -1278,15 +1278,16 @@ namespace Altinn.AccessManagement.Tests.Controllers
         [MemberData(nameof(TestDataRevokeOfferedDelegationExternal.FromPersonToOrganization), MemberType = typeof(TestDataRevokeOfferedDelegationExternal))]
         [MemberData(nameof(TestDataRevokeOfferedDelegationExternal.FromOrganizationToOrganization), MemberType = typeof(TestDataRevokeOfferedDelegationExternal))]
         [MemberData(nameof(TestDataRevokeOfferedDelegationExternal.FromOrganizationToPerson), MemberType = typeof(TestDataRevokeOfferedDelegationExternal))]
-        public async Task RevokeRightsOfferedDelegations_ReturnNoContent(RevokeOfferedDelegationExternal input, string headerKey, string headerValue)
+        public async Task RevokeRightsOfferedDelegations_ReturnNoContent(string userToken, RevokeOfferedDelegationExternal input, string partyRouteValue, string headerKey = null, string headerValue = null)
         {
-            var token = PrincipalUtil.GetToken(20001337, 50002203, 3);
-            var client = GetTestClient(token, WithPDPMock);
-            client.DefaultRequestHeaders.Add(headerKey, headerValue);
+            var client = GetTestClient(userToken, WithPDPMock);
+            if (headerKey != null && headerValue != null)
+            {
+                client.DefaultRequestHeaders.Add(headerKey, headerValue);
+            }
 
             // Act
-            var reporteeType = headerKey == IdentifierUtil.OrganizationNumberHeader ? "organization" : "person";
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{reporteeType}/rights/delegation/offered/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)));
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{partyRouteValue}/rights/delegation/offered/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)));
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
@@ -1303,15 +1304,16 @@ namespace Altinn.AccessManagement.Tests.Controllers
         [MemberData(nameof(TestDataRevokeReceivedDelegationExternal.FromPersonToOrganization), MemberType = typeof(TestDataRevokeReceivedDelegationExternal))]
         [MemberData(nameof(TestDataRevokeReceivedDelegationExternal.FromOrganizationToOrganization), MemberType = typeof(TestDataRevokeReceivedDelegationExternal))]
         [MemberData(nameof(TestDataRevokeReceivedDelegationExternal.FromOrganizationToPerson), MemberType = typeof(TestDataRevokeReceivedDelegationExternal))]
-        public async Task RevokeRightsReceivedDelegations_ReturnNoContent(RevokeReceivedDelegationExternal input, string headerKey, string headerValue)
+        public async Task RevokeRightsReceivedDelegations_ReturnNoContent(string userToken, RevokeReceivedDelegationExternal input, string partyRouteValue, string headerKey = null, string headerValue = null)
         {
-            var token = PrincipalUtil.GetToken(20001337, 50002203, 3);
-            var client = GetTestClient(token, WithPDPMock);
-            client.DefaultRequestHeaders.Add(headerKey, headerValue);
+            var client = GetTestClient(userToken, WithPDPMock);
+            if (headerKey != null && headerValue != null)
+            {
+                client.DefaultRequestHeaders.Add(headerKey, headerValue);
+            }
 
             // Act
-            var reporteeType = headerKey == IdentifierUtil.OrganizationNumberHeader ? "organization" : "person";
-            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{reporteeType}/rights/delegation/received/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)));
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/internal/{partyRouteValue}/rights/delegation/received/revoke", new StringContent(JsonSerializer.Serialize(input), new MediaTypeHeaderValue(MediaTypeNames.Application.Json)));
 
             // Assert
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);

--- a/test/Altinn.AccessManagement.Tests/Data/TestDataRevokeOfferedDelegationExternal.cs
+++ b/test/Altinn.AccessManagement.Tests/Data/TestDataRevokeOfferedDelegationExternal.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Resolvers;
 using Altinn.AccessManagement.Models;
-using Altinn.AccessManagement.Utilities;
+using Altinn.AccessManagement.Tests.Util;
 
 /// <summary>
 /// testdata
@@ -13,15 +13,33 @@ public static class TestDataRevokeOfferedDelegationExternal
 {
     private static string PersonPaulaSSN => "02056260016";
 
+    private static int PersonPaulaUserId => 20000095;
+
+    private static int PersonPaulaPartyId => 50002203;
+
     private static string PersonOrjanSSN => "27099450067";
+
+    private static int PersonOrjanUserId => 20001337;
+
+    private static int PersonOrjanPartyId => 50003899;
 
     private static string ResourceOrg => "org1";
 
     private static string ResourceAppId => "app1";
 
-    private static string OrganizationOrstadAccounting => "910459880";
+    private static string OrganizationOrstaAccounting => "910459880";
+
+    private static int OrganizationOrstaPartyId => 50005545;
+
+    private static string PersonKasperSSN => "07124912037";
+
+    private static int PersonKasperUserId => 20000490;
+
+    private static int PersonKasperPartyId => 50002598;
 
     private static string OrganizationKolbjorn => "810419342";
+
+    private static int OrganizationKolbjornPartyId => 50004226;
 
     private static string EnterpriseUsername => "OrstaECUser";
 
@@ -31,55 +49,55 @@ public static class TestDataRevokeOfferedDelegationExternal
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromPersonToPerson() => [[
-            NewRevokeOfferedModel(
-                WithRevokeOfferedTo(Urn.Altinn.Person.IdentifierNo, PersonPaulaSSN),
-                WithRevokeOfferedAction("read"),
-                WithRevokeOfferedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
-                WithRevokeOfferedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-            IdentifierUtil.PersonHeader,
-            PersonOrjanSSN,
-        ]];
+        PrincipalUtil.GetToken(PersonOrjanUserId, PersonOrjanPartyId, 3),
+        NewRevokeOfferedModel(
+            WithRevokeOfferedTo(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, PersonPaulaUserId),
+            WithRevokeOfferedAction("read"),
+            WithRevokeOfferedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
+            WithRevokeOfferedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
+        PersonOrjanPartyId
+    ]];
 
     /// <summary>
     /// An input model that specifies revoking an existing delegation from Paula to Orstad Accounting. The delegation should 
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromPersonToOrganization() => [[
+        PrincipalUtil.GetToken(PersonPaulaUserId, PersonPaulaPartyId, 3),
         NewRevokeOfferedModel(
-            WithRevokeOfferedTo(Urn.Altinn.Organization.IdentifierNo, OrganizationOrstadAccounting),
+            WithRevokeOfferedTo(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, OrganizationOrstaPartyId),
             WithRevokeOfferedAction("read"),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.PersonHeader,
-        PersonPaulaSSN,
-        ]];
+        PersonPaulaPartyId
+    ]];
 
     /// <summary>
     /// a
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromOrganizationToOrganization() => [[
+        PrincipalUtil.GetToken(PersonKasperUserId, PersonKasperPartyId, 3),
         NewRevokeOfferedModel(
-            WithRevokeOfferedTo(Urn.Altinn.Organization.IdentifierNo, OrganizationKolbjorn),
+            WithRevokeOfferedTo(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, OrganizationKolbjornPartyId),
             WithRevokeOfferedAction("read"),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.OrganizationNumberHeader,
-        OrganizationOrstadAccounting,
-        ]];
+        OrganizationOrstaPartyId
+    ]];
 
     /// <summary>
     /// summary
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromOrganizationToPerson() => [[
+        PrincipalUtil.GetToken(PersonKasperUserId, PersonKasperPartyId, 3),
         NewRevokeOfferedModel(
-            WithRevokeOfferedTo(Urn.Altinn.Person.IdentifierNo, PersonPaulaSSN),
+            WithRevokeOfferedTo(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, PersonPaulaUserId),
             WithRevokeOfferedAction("read"),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.OrganizationNumberHeader,
-        OrganizationOrstadAccounting,
+        OrganizationOrstaPartyId
     ]];
 
     /// <summary>
@@ -87,13 +105,13 @@ public static class TestDataRevokeOfferedDelegationExternal
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromOrganizationToEnterpriseuser() => [[
+        PrincipalUtil.GetToken(PersonKasperUserId, PersonKasperPartyId, 3),
         NewRevokeOfferedModel(
             WithRevokeOfferedTo(Urn.Altinn.EnterpriseUser.Username, EnterpriseUsername),
             WithRevokeOfferedAction("read"),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
             WithRevokeOfferedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.OrganizationNumberHeader,
-        OrganizationOrstadAccounting,
+        OrganizationOrstaPartyId
     ]];
 
     private static RevokeOfferedDelegationExternal NewRevokeOfferedModel(params Action<RevokeOfferedDelegationExternal>[] actions)

--- a/test/Altinn.AccessManagement.Tests/Data/TestDataRevokeReceivedDelegationExternal.cs
+++ b/test/Altinn.AccessManagement.Tests/Data/TestDataRevokeReceivedDelegationExternal.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.NetworkInformation;
 using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Resolvers;
 using Altinn.AccessManagement.Models;
-using Altinn.AccessManagement.Utilities;
+using Altinn.AccessManagement.Tests.Util;
 
 /// <summary>
 /// testdata
@@ -14,15 +13,33 @@ public static class TestDataRevokeReceivedDelegationExternal
 {
     private static string PersonPaulaSSN => "02056260016";
 
+    private static int PersonPaulaUserId => 20000095;
+
+    private static int PersonPaulaPartyId => 50002203;
+
     private static string PersonOrjanSSN => "27099450067";
+
+    private static int PersonOrjanUserId => 20001337;
+
+    private static int PersonOrjanPartyId => 50003899;
 
     private static string ResourceOrg => "org1";
 
     private static string ResourceAppId => "app1";
 
-    private static string OrganizationOrstadAccounting => "910459880";
+    private static string OrganizationOrstaAccounting => "910459880";
+
+    private static int OrganizationOrstaPartyId => 50005545;
+
+    private static string PersonKasperSSN => "07124912037";
+
+    private static int PersonKasperUserId => 20000490;
+
+    private static int PersonKasperPartyId => 50002598;
 
     private static string OrganizationKolbjorn => "810419342";
+
+    private static int OrganizationKolbjornPartyId => 50004226;
 
     private static string EnterpriseUsername => "OrstaECUser";
 
@@ -32,69 +49,55 @@ public static class TestDataRevokeReceivedDelegationExternal
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromPersonToPerson() => [[
-            NewRevokeReceivedModel(
-                WithRevokeReceivedFrom(Urn.Altinn.Person.IdentifierNo, PersonOrjanSSN),
-                WithRevokeReceivedAction("read"),
-                WithRevokeReceivedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
-                WithRevokeReceivedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-            IdentifierUtil.PersonHeader,
-            PersonPaulaSSN,
-        ]];
+        PrincipalUtil.GetToken(PersonOrjanUserId, PersonOrjanPartyId, 3),
+        NewRevokeReceivedModel(
+            WithRevokeReceivedFrom(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, PersonPaulaUserId),
+            WithRevokeReceivedAction("read"),
+            WithRevokeReceivedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
+            WithRevokeReceivedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
+        PersonOrjanPartyId
+    ]];
 
     /// <summary>
     /// An input model that specifies an delegation from Paula
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromPersonToOrganization() => [[
+        PrincipalUtil.GetToken(PersonOrjanUserId, PersonOrjanPartyId, 3),
         NewRevokeReceivedModel(
-            WithRevokeReceivedFrom(Urn.Altinn.Person.IdentifierNo, PersonPaulaSSN),
+            WithRevokeReceivedFrom(AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, PersonPaulaUserId),
             WithRevokeReceivedAction("read"),
             WithRevokeReceivedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
             WithRevokeReceivedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.OrganizationNumberHeader,
-        OrganizationOrstadAccounting,
-        ]];
+        OrganizationOrstaPartyId
+    ]];
 
     /// <summary>
     /// a
     /// </summary>
     /// <returns></returns>
     public static IEnumerable<object[]> FromOrganizationToOrganization() => [[
+        PrincipalUtil.GetToken(PersonOrjanUserId, PersonOrjanPartyId, 3),
         NewRevokeReceivedModel(
-            WithRevokeReceivedFrom(Urn.Altinn.Organization.IdentifierNo, OrganizationOrstadAccounting),
+            WithRevokeReceivedFrom(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, OrganizationOrstaPartyId),
             WithRevokeReceivedAction("read"),
             WithRevokeReceivedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
             WithRevokeReceivedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.OrganizationNumberHeader,
-        OrganizationKolbjorn,
-        ]];
-
-    /// <summary>
-    /// summary
-    /// </summary>
-    /// <returns></returns>
-    public static IEnumerable<object[]> FromOrganizationToPerson() => [[
-        NewRevokeReceivedModel(
-            WithRevokeReceivedFrom(Urn.Altinn.Organization.IdentifierNo, OrganizationOrstadAccounting),
-            WithRevokeReceivedAction("read"),
-            WithRevokeReceivedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
-            WithRevokeReceivedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.PersonHeader,
-        PersonPaulaSSN,
+        OrganizationKolbjornPartyId
     ]];
 
     /// <summary>
     /// summary
     /// </summary>
     /// <returns></returns>
-    public static IEnumerable<object[]> FromOrganizationToEnterpriseuser() => [[
+    public static IEnumerable<object[]> FromOrganizationToPerson() => [[
+        PrincipalUtil.GetToken(PersonPaulaUserId, PersonPaulaPartyId, 3),
         NewRevokeReceivedModel(
-            WithRevokeReceivedFrom(Urn.Altinn.Organization.IdentifierNo, OrganizationOrstadAccounting),
+            WithRevokeReceivedFrom(AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, OrganizationOrstaPartyId),
             WithRevokeReceivedAction("read"),
             WithRevokeReceivedResource(Urn.Altinn.Resource.AppOwner, ResourceOrg),
             WithRevokeReceivedResource(Urn.Altinn.Resource.AppId, ResourceAppId)),
-        IdentifierUtil.PersonHeader,
-        EnterpriseUsername,
+        PersonPaulaPartyId
     ]];
 
     private static RevokeReceivedDelegationExternal NewRevokeReceivedModel(params Action<RevokeReceivedDelegationExternal>[] actions)

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Asle to Hovdebygda.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Asle to Hovdebygda.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Asle to Hovdebygda
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:organizationnumber",
+              "value": "{{toOrg}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toOrg: 910434217
+  resourceId: devtest_gar_authparties-person-to-org
+  auth_tokenType: Personal
+  auth_userId: 20001121
+  auth_partyId: 50003229
+  auth_ssn: '17105431031'
+  party: 50003229
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 201 CREATED", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Kasper to Asle.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Kasper to Asle.bru
@@ -1,0 +1,63 @@
+meta {
+  name: Kasper to Asle
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:person:identifier-no",
+              "value": "{{toSsn}}"
+          },
+          {
+              "id": "urn:altinn:person:lastname",
+              "value": "{{toLastName}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toSsn: '17105431031'
+  toLastName: Natvik
+  resourceId: devtest_gar_authparties-person-to-person
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50002598
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 201 CREATED", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Ørsta to Asle.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Ørsta to Asle.bru
@@ -1,0 +1,63 @@
+meta {
+  name: Ørsta to Asle
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:person:identifier-no",
+              "value": "{{toSsn}}"
+          },
+          {
+              "id": "urn:altinn:person:lastname",
+              "value": "{{toLastName}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toSsn: '17105431031'
+  toLastName: Natvik
+  resourceId: devtest_gar_authparties-main-to-person
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50005545
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 201 CREATED", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Ørsta to Hovdebygda.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/CreateDelegation/Revoke Test Data Setup/Ørsta to Hovdebygda.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Ørsta to Hovdebygda
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:organizationnumber",
+              "value": "{{toOrg}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toOrg: 910434217
+  resourceId: devtest_gar_authparties-main-to-org
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50005545
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 201 CREATED", function() {
+    expect(res.status).to.equal(201);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Asle to Hovdebygda.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Asle to Hovdebygda.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Asle to Hovdebygda
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:partyid",
+              "value": "{{toPartyId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toPartyId: 50004674
+  resourceId: devtest_gar_authparties-person-to-org
+  auth_tokenType: Personal
+  auth_userId: 20001121
+  auth_partyId: 50003229
+  auth_ssn: '17105431031'
+  party: 50003229
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Kasper to Asle.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Kasper to Asle.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Kasper to Asle
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:userid",
+              "value": "{{toUserId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toUserId: 20001121
+  resourceId: devtest_gar_authparties-person-to-person
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50002598
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Ørsta to Asle.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Ørsta to Asle.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Ørsta to Asle
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:userid",
+              "value": "{{toUserId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toUserId: 20001121
+  resourceId: devtest_gar_authparties-main-to-person
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50005545
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Ørsta to Hovdebygda.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeOffered/Ørsta to Hovdebygda.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Ørsta to Hovdebygda
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/offered/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "to": [
+          {
+              "id": "urn:altinn:partyid",
+              "value": "{{toPartyId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  toPartyId: 50004674
+  resourceId: devtest_gar_authparties-main-to-org
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  party: 50005545
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Asle From Kasper.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Asle From Kasper.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Asle From Kasper
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/received/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "from": [
+          {
+              "id": "urn:altinn:userid",
+              "value": "{{fromUserId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  fromUserId: 20000490
+  resourceId: devtest_gar_authparties-person-to-person
+  auth_tokenType: Personal
+  auth_userId: 20001121
+  auth_partyId: 50003229
+  auth_ssn: '17105431031'
+  party: 50003229
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Asle From Ørsta.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Asle From Ørsta.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Asle From Ørsta
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/received/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "from": [
+          {
+              "id": "urn:altinn:partyid",
+              "value": "{{fromPartyId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  fromPartyId: 50005545
+  resourceId: devtest_gar_authparties-main-to-person
+  auth_tokenType: Personal
+  auth_userId: 20001121
+  auth_partyId: 50003229
+  auth_ssn: '17105431031'
+  party: 50003229
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Hovdebygda From Asle.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Hovdebygda From Asle.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Hovdebygda From Asle
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/received/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "from": [
+          {
+              "id": "urn:altinn:partyid",
+              "value": "{{fromPartyId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  fromPartyId: 50003229
+  resourceId: devtest_gar_authparties-person-to-org
+  auth_tokenType: Personal
+  auth_userId: 20001121
+  auth_partyId: 50003229
+  auth_ssn: '17105431031'
+  party: 50004674
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Hovdebygda From Ørsta.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/RevokeReceived/Hovdebygda From Ørsta.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Hovdebygda From Ørsta
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/{{party}}/rights/delegation/received/revoke
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+      "from": [
+          {
+              "id": "urn:altinn:partyid",
+              "value": "{{fromPartyId}}"
+          }
+      ],
+      "rights": [
+          {
+              "resource": [
+                  {
+                      "id": "urn:altinn:resource",
+                      "value": "{{resourceId}}"
+                  }
+              ],
+              "action": "read"
+          }
+      ]
+  }
+}
+
+vars:pre-request {
+  fromPartyId: 50005545
+  resourceId: devtest_gar_authparties-main-to-org
+  auth_tokenType: Personal
+  auth_userId: 20001121
+  auth_partyId: 50003229
+  auth_ssn: '17105431031'
+  party: 50004674
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 204 No Content", function() {
+    expect(res.status).to.equal(204);
+  });
+}


### PR DESCRIPTION
## Description
Cleanup of valid input attributes and resolver logic to only support the internal attribute ids used by the current Altinn 2 integration: urn:altinn:userid and urn:altinn:partyid

Added manual Bruno test requests for all scenarios for both received and offered for both userid and party id

## Related Issue(s)
- #613

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [x] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
