### PR TITLE
Internal API endpoint for clearing access cache

### DIFF
--- a/src/Altinn.AccessManagement.Core/Clients/Interfaces/IAltinn2RightsClient.cs
+++ b/src/Altinn.AccessManagement.Core/Clients/Interfaces/IAltinn2RightsClient.cs
@@ -25,5 +25,15 @@ namespace Altinn.AccessManagement.Core.Clients.Interfaces
         /// <param name="delegationRequest">the delegation request model</param>
         /// <returns>Delegation Response</returns>
         Task<DelegationActionResult> PostDelegation(int authenticatedUserId, int reporteePartyId, SblRightDelegationRequest delegationRequest);
+
+        /// <summary>
+        /// Operation to clear a recipients cached rights from a given reportee/from party, and the recipients authorized parties/reportees
+        /// </summary>
+        /// <param name="fromPartyId">The party id of the from party</param>
+        /// <param name="toPartyId">The party id of the to party</param>
+        /// <param name="toUserId">The user id of the to party (if the recipient is a user)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>HttpResponse</returns>
+        Task<HttpResponseMessage> ClearReporteeRights(int fromPartyId, int toPartyId, int toUserId = 0, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IAltinn2RightsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IAltinn2RightsService.cs
@@ -1,4 +1,5 @@
 using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Core.Services.Interfaces;
 
@@ -21,5 +22,14 @@ public interface IAltinn2RightsService
     /// <param name="partyId">reportee</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>list of delgations</returns>
-    public Task<List<RightDelegation>> GetReceivedRights(int partyId, CancellationToken cancellationToken = default);
+    Task<List<RightDelegation>> GetReceivedRights(int partyId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Operation to clear a recipients cached rights from a given reportee/from party, and the recipients authorized parties/reportees
+    /// </summary>
+    /// <param name="fromPartyId">The party id of the from party</param>
+    /// <param name="toAttribute">Attribute model identifying the recipient/to party</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>HttpResponse</returns>
+    Task<HttpResponseMessage> ClearReporteeRights(int fromPartyId, BaseAttribute toAttribute, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
+++ b/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
@@ -110,4 +110,11 @@ public class Altinn2RightsClient : IAltinn2RightsClient
         delegationResult.Errors.Add("SBLBridge", $"Unable to reach Altinn 2 for delegation of Altinn 2 service. HttpStatusCode: {response.StatusCode}");
         return delegationResult;
     }
+
+    /// <inheritdoc />
+    public async Task<HttpResponseMessage> ClearReporteeRights(int fromPartyId, int toPartyid, int toUserId = 0, CancellationToken cancellationToken = default)
+    {
+        UriBuilder endpoint = new UriBuilder($"{_sblBridgeSettings.BaseApiUrl}cache/api/clearreporteerights?reporteePartyId={fromPartyId}&coveredByPartyId={toPartyid}&coveredByUserId={toUserId}");
+        return await _client.PutAsync(endpoint.Uri.ToString(), null, cancellationToken);
+    }
 }

--- a/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
+++ b/src/Altinn.AccessManagement.Integration/Clients/Altinn2RightsClient.cs
@@ -112,9 +112,9 @@ public class Altinn2RightsClient : IAltinn2RightsClient
     }
 
     /// <inheritdoc />
-    public async Task<HttpResponseMessage> ClearReporteeRights(int fromPartyId, int toPartyid, int toUserId = 0, CancellationToken cancellationToken = default)
+    public async Task<HttpResponseMessage> ClearReporteeRights(int fromPartyId, int toPartyId, int toUserId = 0, CancellationToken cancellationToken = default)
     {
-        UriBuilder endpoint = new UriBuilder($"{_sblBridgeSettings.BaseApiUrl}cache/api/clearreporteerights?reporteePartyId={fromPartyId}&coveredByPartyId={toPartyid}&coveredByUserId={toUserId}");
+        UriBuilder endpoint = new UriBuilder($"{_sblBridgeSettings.BaseApiUrl}cache/api/clearreporteerights?reporteePartyId={fromPartyId}&coveredByPartyId={toPartyId}&coveredByUserId={toUserId}");
         return await _client.PutAsync(endpoint.Uri.ToString(), null, cancellationToken);
     }
 }

--- a/src/Altinn.AccessManagement/Controllers/RightsInternalController.cs
+++ b/src/Altinn.AccessManagement/Controllers/RightsInternalController.cs
@@ -7,7 +7,6 @@ using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Helpers;
 using Altinn.AccessManagement.Core.Helpers.Extensions;
 using Altinn.AccessManagement.Core.Models;
-using Altinn.AccessManagement.Core.Resolvers;
 using Altinn.AccessManagement.Core.Services.Interfaces;
 using Altinn.AccessManagement.Models;
 using Altinn.AccessManagement.Utilities;
@@ -387,6 +386,34 @@ namespace Altinn.AccessManagement.Controllers
                 _logger.LogError(StatusCodes.Status500InternalServerError, ex, "Internal exception occurred during Rights Delegation");
                 return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, detail: "Internal Server Error"));
             }
+        }
+
+        /// <summary>
+        /// Clears access chaching for a given recipient having received right delegations from the reportee party, in order for the rights to take effect as imidiately as possible in the distributed authorization system between Altinn 2 and Altinn 3.
+        /// </summary>
+        /// <param name="party">Used to specify the reportee party id the authenticated user is acting on behalf of.</param>
+        /// <param name="to">Attribute specification of the uuid of the recipient to clear access caching for</param>
+        /// <param name="cancellationToken">Cancellation token used for cancelling the inbound HTTP</param>
+        [Authorize(Policy = AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE)]
+        [ActionName(nameof(ClearAccessCache))]
+        [HttpPut("internal/{party}/accesscache/clear")]
+        [Produces(MediaTypeNames.Application.Json, Type = typeof(void))]
+        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+        [FeatureGate(FeatureFlags.RightsDelegationApi)]
+        public async Task<IActionResult> ClearAccessCache([FromRoute] int party, [FromBody] BaseAttributeExternal to, CancellationToken cancellationToken)
+        {
+            BaseAttribute toAttribute = _mapper.Map<BaseAttribute>(to);
+            HttpResponseMessage response = await _rightsForAltinn2.ClearReporteeRights(party, toAttribute, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new ObjectResult(ProblemDetailsFactory.CreateProblemDetails(HttpContext, (int)response.StatusCode, detail: $"Could not complete the request. Reason: {response.ReasonPhrase}"));
+            }
+
+            return Ok();
         }
     }
 }

--- a/test/Altinn.AccessManagement.Tests/Controllers/Altinn2RightsControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/Altinn2RightsControllerTest.cs
@@ -160,8 +160,7 @@ public class Altinn2RightsControllerTest : IClassFixture<CustomWebApplicationFac
             50005545, // From Ørsta
             new BaseAttributeExternal { Type = Urn.Altinn.EnterpriseUser.Uuid, Value = "00000000-0000-0000-0002-000000010727" }, // To OrstaECUser
             AssertStatusCode(StatusCodes.Status200OK)
-        },
-        
+        }
     };
 
     private static Action<HttpResponseMessage> Assertions(params Action<HttpResponseMessage>[] assertions) => response =>

--- a/test/Altinn.AccessManagement.Tests/Controllers/Altinn2RightsControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/Altinn2RightsControllerTest.cs
@@ -127,7 +127,7 @@ public class Altinn2RightsControllerTest : IClassFixture<CustomWebApplicationFac
     [MemberData(nameof(ClearAccessCache_ReturnOk_input))]
     public async Task ClearAccessCache_ReturnOk(string authnUserToken, int party, BaseAttributeExternal toAttribute, Action<HttpResponseMessage> assert)
     {
-        var client = NewClient(NewServiceCollection(WithServiceMoq), [WithClientRoute("accessmanagement/api/v1/")]);
+        var client = NewClient(NewServiceCollection(WithServiceMoq), WithClientRoute("accessmanagement/api/v1/"));
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authnUserToken);
 
         HttpResponseMessage response = await client.PutAsync($"internal/{party}/accesscache/clear", new StringContent(JsonSerializer.Serialize(toAttribute), Encoding.UTF8, MediaTypeNames.Application.Json));
@@ -170,7 +170,7 @@ public class Altinn2RightsControllerTest : IClassFixture<CustomWebApplicationFac
     [MemberData(nameof(ClearAccessCache_ReturnBadRequest_input))]
     public async Task ClearAccessCache_ReturnBadRequest(string authnUserToken, int party, BaseAttributeExternal toAttribute, Action<HttpResponseMessage> assert)
     {
-        var client = NewClient(NewServiceCollection(WithServiceMoq), [WithClientRoute("accessmanagement/api/v1/")]);
+        var client = NewClient(NewServiceCollection(WithServiceMoq), WithClientRoute("accessmanagement/api/v1/"));
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authnUserToken);
 
         HttpResponseMessage response = await client.PutAsync($"internal/{party}/accesscache/clear", new StringContent(JsonSerializer.Serialize(toAttribute), Encoding.UTF8, MediaTypeNames.Application.Json));

--- a/test/Altinn.AccessManagement.Tests/Mocks/Altinn2RightsClientMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/Altinn2RightsClientMock.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Enums;
@@ -46,6 +48,12 @@ namespace Altinn.AccessManagement.Tests.Mocks
             result.Rights = GetSblRightsDelegationResult($"se_{serviceCode}_{serviceEditionCode}", reporteePartyId.ToString(), delegationRequest.To.Value, authenticatedUserId.ToString());
 
             return Task.FromResult(result);
+        }
+
+        /// <inheritdoc/>
+        public Task<HttpResponseMessage> ClearReporteeRights(int fromPartyId, int toPartyId, int toUserId = 0, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
         }
 
         private static List<RightDelegationResult> GetSblRightsDelegationResult(string resourceId, string reporteePartyId, string to, string by)

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to Asle.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to Asle.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Ørsta to Asle
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/50005545/accesscache/clear
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:person:uuid",
+    "value": "182ad02e-34b5-431e-8ae2-2bdf14eaa436"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to Hovdebygda.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to Hovdebygda.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Ørsta to Hovdebygda
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/50005545/accesscache/clear
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:organization:uuid",
+    "value": "44d9839a-8be6-4735-ba88-186992493cfe"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to OrstaECUser.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to OrstaECUser.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Ørsta to OrstaECUser
+  type: http
+  seq: 3
+}
+
+put {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/50005545/accesscache/clear
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+body:json {
+  {
+    "type": "urn:altinn:enterpriseuser:uuid",
+    "value": "002209f9-57fc-4d7c-9a60-ef0ab8e4eb06"
+  }
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}


### PR DESCRIPTION
## Description
- Added new endpoint along-side existing internal rights operations
- Added implementation in Altinn2RightService and Altinn2RightsClient
- Added Bruno manual test requests

## Related Issue(s)
- #648

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [x] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
