### PR TITLE
AuthorizedParties: Changed format of Altinn App Id from database to match ResourceRegistry format

### DIFF
--- a/src/Altinn.AccessManagement.Core/Models/AuthorizedParty/AuthorizedParty.cs
+++ b/src/Altinn.AccessManagement.Core/Models/AuthorizedParty/AuthorizedParty.cs
@@ -135,6 +135,7 @@ public class AuthorizedParty
     /// <param name="resourceId">The list of resource IDs to add to the authorized party (and any subunits) list of authorized resources</param>
     public void EnrichWithResourceAccess(string resourceId)
     {
+        resourceId = MapAppIdToResourceId(resourceId);
         OnlyHierarchyElementWithNoAccess = false;
         AuthorizedResources.Add(resourceId);
 
@@ -145,5 +146,16 @@ public class AuthorizedParty
                 subunit.EnrichWithResourceAccess(resourceId);
             }
         }
+    }
+
+    private static string MapAppIdToResourceId(string altinnAppId)
+    {
+        string[] orgAppSplit = altinnAppId.Split('/');
+        if (orgAppSplit.Length == 2)
+        {
+            return $"app_{orgAppSplit[0]}_{orgAppSplit[1]}";
+        }
+
+        return altinnAppId;
     }
 }

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/AccessManagerGettingOrgList/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/AccessManagerGettingOrgList/BothAltinn3AndAltinn2.json
@@ -25,7 +25,7 @@
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
-          "ttd/am-devtest-sub-to-org",
+          "app_ttd_am-devtest-sub-to-org",
           "devtest_gar_authparties-main-to-org",
           "devtest_gar_authparties-sub-to-org"
         ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToOrg/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToOrg/BothAltinn3AndAltinn2.json
@@ -43,7 +43,7 @@
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
-          "ttd/am-devtest-sub-to-org",
+          "app_ttd_am-devtest-sub-to-org",
           "devtest_gar_authparties-main-to-org",
           "devtest_gar_authparties-sub-to-org"
         ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToOrg/OnlyAltinn3.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToOrg/OnlyAltinn3.json
@@ -25,7 +25,7 @@
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
-          "ttd/am-devtest-sub-to-org",
+          "app_ttd_am-devtest-sub-to-org",
           "devtest_gar_authparties-main-to-org",
           "devtest_gar_authparties-sub-to-org"
         ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToPerson/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToPerson/BothAltinn3AndAltinn2.json
@@ -44,7 +44,7 @@
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
           "devtest_gar_authparties-main-to-person",
-          "ttd/am-devtest-sub-to-person"
+          "app_ttd_am-devtest-sub-to-person"
         ],
         "authorizedRoles": [
           "REGNA",

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToPerson/OnlyAltinn3.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/MainUnitAndSubUnitToPerson/OnlyAltinn3.json
@@ -26,7 +26,7 @@
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
           "devtest_gar_authparties-main-to-person",
-          "ttd/am-devtest-sub-to-person"
+          "app_ttd_am-devtest-sub-to-person"
         ],
         "authorizedRoles": [],
         "subunits": []

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonGettingA3Delegator/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonGettingA3Delegator/BothAltinn3AndAltinn2.json
@@ -10,7 +10,7 @@
   "onlyHierarchyElementWithNoAccess": false,
   "authorizedResources": [
     "devtest_gar_authparties-person-to-person",
-    "ttd/am-devtest-person-to-person"
+    "app_ttd_am-devtest-person-to-person"
   ],
   "authorizedRoles": [
     "UTINN"

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonGettingA3Delegator/OnlyAltinn3.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonGettingA3Delegator/OnlyAltinn3.json
@@ -10,7 +10,7 @@
   "onlyHierarchyElementWithNoAccess": false,
   "authorizedResources": [
     "devtest_gar_authparties-person-to-person",
-    "ttd/am-devtest-person-to-person"
+    "app_ttd_am-devtest-person-to-person"
   ],
   "authorizedRoles": [],
   "subunits": []

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonGettingOwnList/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonGettingOwnList/BothAltinn3AndAltinn2.json
@@ -27,7 +27,7 @@
     "onlyHierarchyElementWithNoAccess": false,
     "authorizedResources": [
       "devtest_gar_authparties-person-to-person",
-      "ttd/am-devtest-person-to-person"
+      "app_ttd_am-devtest-person-to-person"
     ],
     "authorizedRoles": [
       "UTINN"

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToOrg/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToOrg/BothAltinn3AndAltinn2.json
@@ -27,7 +27,7 @@
     "onlyHierarchyElementWithNoAccess": false,
     "authorizedResources": [
       "devtest_gar_authparties-person-to-org",
-      "ttd/am-devtest-person-to-org"
+      "app_ttd_am-devtest-person-to-org"
     ],
     "authorizedRoles": [
       "UTINN"

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToOrg/OnlyAltinn3.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToOrg/OnlyAltinn3.json
@@ -11,7 +11,7 @@
     "onlyHierarchyElementWithNoAccess": false,
     "authorizedResources": [
       "devtest_gar_authparties-person-to-org",
-      "ttd/am-devtest-person-to-org"
+      "app_ttd_am-devtest-person-to-org"
     ],
     "authorizedRoles": [],
     "subunits": []

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToPerson/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToPerson/BothAltinn3AndAltinn2.json
@@ -27,7 +27,7 @@
     "onlyHierarchyElementWithNoAccess": false,
     "authorizedResources": [
       "devtest_gar_authparties-person-to-person",
-      "ttd/am-devtest-person-to-person"
+      "app_ttd_am-devtest-person-to-person"
     ],
     "authorizedRoles": [
       "UTINN"

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToPerson/OnlyAltinn3.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/PersonToPerson/OnlyAltinn3.json
@@ -11,7 +11,7 @@
     "onlyHierarchyElementWithNoAccess": false,
     "authorizedResources": [
       "devtest_gar_authparties-person-to-person",
-      "ttd/am-devtest-person-to-person"
+      "app_ttd_am-devtest-person-to-person"
     ],
     "authorizedRoles": [],
     "subunits": []

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetEnterpriseUserList/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetEnterpriseUserList/BothAltinn3AndAltinn2.json
@@ -41,7 +41,7 @@
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
-          "ttd/am-devtest-sub-to-org",
+          "app_ttd_am-devtest-sub-to-org",
           "devtest_gar_authparties-main-to-org",
           "devtest_gar_authparties-sub-to-org"
         ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetOrgList/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetOrgList/BothAltinn3AndAltinn2.json
@@ -25,7 +25,7 @@
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
-          "ttd/am-devtest-sub-to-org",
+          "app_ttd_am-devtest-sub-to-org",
           "devtest_gar_authparties-main-to-org",
           "devtest_gar_authparties-sub-to-org"
         ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetPersonList/BothAltinn3AndAltinn2.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetPersonList/BothAltinn3AndAltinn2.json
@@ -43,7 +43,7 @@
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
-          "ttd/am-devtest-sub-to-org",
+          "app_ttd_am-devtest-sub-to-org",
           "devtest_gar_authparties-main-to-org",
           "devtest_gar_authparties-sub-to-org"
         ],

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/SubUnitToPerson/OnlyAltinn3.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/SubUnitToPerson/OnlyAltinn3.json
@@ -23,7 +23,7 @@
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "authorizedResources": [
-          "ttd/am-devtest-sub-to-person",
+          "app_ttd_am-devtest-sub-to-person",
           "devtest_gar_authparties-sub-to-person"
         ],
         "authorizedRoles": [],


### PR DESCRIPTION
## Description
Added mapping function to map the Altinn App Id from the delegation change table in Postgres: "{org}/{appName}" to match the format used by the ResourceRegistry: "app_{org}_{appName}"

## Related Issue(s)
- #661

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [x] Relevant integration test added (required for functional changes)
- [x] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
