### PR TITLE
Update for PIP API with support for organization party subject lookup

### DIFF
--- a/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
+++ b/src/Altinn.AccessManagement.Core/Services/PolicyInformationPoint.cs
@@ -211,7 +211,6 @@ namespace Altinn.AccessManagement.Core.Services
 
             if (!validSubjectUser && !validSubjectParty)
             {
-
                 result.Errors.Add("request.Subject", $"Missing valid subject on request. Valid subject attribute types: either {AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute} or {AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute}");
                 return result;
             }


### PR DESCRIPTION
## Description
Rewrite of PolicyInformationPoint.FindAllDelegations in order to support lookup of delegations providing only subject party id for a receiving organization.

- Moved fetch of MainUnit as first step, in order to perform what was previously done in two steps for lookup of direct delegations to Subject user be possible in a single database lookup.
- Lookup of direct delegations to organization partyIds both support a Subject users KeyRoleUnits or lookup for a single subject organization party

## Related Issue(s)
- #681

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
