### PR TITLE
Fix so GET /authorizedparty/{{partyId}} works for subunits

### DIFF
--- a/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
+++ b/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
@@ -113,7 +113,8 @@ public class AuthorizedPartiesController : ControllerBase
             }
 
             List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, cancellationToken);
-            AuthorizedParty authorizedParty = authorizedParties.Find(p => p.PartyId == partyId);
+            AuthorizedParty authorizedParty = authorizedParties.FirstOrDefault(ap => ap.PartyId == partyId && !ap.OnlyHierarchyElementWithNoAccess)
+                ?? authorizedParties.SelectMany(ap => ap.Subunits).FirstOrDefault(subunit => subunit.PartyId == partyId);
 
             if (authorizedParty == null)
             {

--- a/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
+++ b/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
@@ -113,7 +113,7 @@ public class AuthorizedPartiesController : ControllerBase
             }
 
             List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, cancellationToken);
-            AuthorizedParty authorizedParty = authorizedParties.FirstOrDefault(ap => ap.PartyId == partyId && !ap.OnlyHierarchyElementWithNoAccess)
+            AuthorizedParty authorizedParty = authorizedParties.Find(ap => ap.PartyId == partyId && !ap.OnlyHierarchyElementWithNoAccess)
                 ?? authorizedParties.SelectMany(ap => ap.Subunits).FirstOrDefault(subunit => subunit.PartyId == partyId);
 
             if (authorizedParty == null)

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetMain.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetMain.bru
@@ -1,0 +1,38 @@
+meta {
+  name: KasperGetMain
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparty/{{partyId}}?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  partyId: 50076451
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetSubunit.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AuthorizedPartyById/KasperGetSubunit.bru
@@ -1,0 +1,38 @@
+meta {
+  name: KasperGetSubunit
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparty/{{partyId}}?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
+  partyId: 50074838
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}


### PR DESCRIPTION
## Description
- Changed query to find PartyId in list of authorized parties to include subunits
- Changed query to find PartyId in list of authorized parties to exclude mainunit if only hierarchy element without access

## Related Issue(s)
- #689

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [x] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
