### PR TITLE
Update to scope requirement for AuthorizedParties API for resource owners

### DIFF
--- a/src/Altinn.AccessManagement.Core/Altinn.AccessManagement.Core.csproj
+++ b/src/Altinn.AccessManagement.Core/Altinn.AccessManagement.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="8.3.0" />
-    <PackageReference Include="Npgsql" Version="8.0.2" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
+++ b/src/Altinn.AccessManagement.Core/Constants/AuthzConstants.cs
@@ -46,14 +46,19 @@
         public const string POLICY_RESOURCEOWNER_AUTHORIZEDPARTIES = "ResourceOwnerAuthorizedParty";
 
         /// <summary>
-        /// Scope giving access to getting authorized parties for a third party, for which the third party have access to one or more of the resource owners services, apps or resources.
+        /// Scope giving access to getting authorized parties for a given subject.
         /// </summary>
-        public const string SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES = "altinn:resourceowner/authorizedparties";
+        public const string SCOPE_AUTHORIZEDPARTIES_ENDUSERSYSTEM = "altinn:accessmanagement/authorizedparties";
 
         /// <summary>
-        /// Scope giving access to getting all authorized parties for a third party
+        /// Scope giving access to getting authorized parties for any third party, for which the third party have access to one or more of the resource owners services, apps or resources.
         /// </summary>
-        public const string SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES_ADMIN = "altinn:resourceowner/authorizedparties.admin";
+        public const string SCOPE_AUTHORIZEDPARTIES_RESOURCEOWNER = "altinn:accessmanagement/authorizedparties.resourceowner";
+
+        /// <summary>
+        /// Scope giving access to getting all authorized parties for any third party
+        /// </summary>
+        public const string SCOPE_AUTHORIZEDPARTIES_ADMIN = "altinn:accessmanagement/authorizedparties.admin";
 
         /// <summary>
         /// Scope giving access to delegations for Maskinporten schemes owned by authenticated party 

--- a/src/Altinn.AccessManagement.Persistence/Altinn.AccessManagement.Persistence.csproj
+++ b/src/Altinn.AccessManagement.Persistence/Altinn.AccessManagement.Persistence.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.2" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
     <PackageReference Include="OpenTelemetry" Version="1.8.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/src/Altinn.AccessManagement/Program.cs
+++ b/src/Altinn.AccessManagement/Program.cs
@@ -297,7 +297,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
         options.AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_READ, policy => policy.Requirements.Add(new ResourceAccessRequirement("read", "altinn_access_management")));
         options.AddPolicy(AuthzConstants.POLICY_ACCESS_MANAGEMENT_WRITE, policy => policy.Requirements.Add(new ResourceAccessRequirement("write", "altinn_access_management")));
         options.AddPolicy(AuthzConstants.POLICY_RESOURCEOWNER_AUTHORIZEDPARTIES, policy =>
-            policy.Requirements.Add(new ScopeAccessRequirement(new string[] { AuthzConstants.SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES, AuthzConstants.SCOPE_RESOURCEOWNER_AUTHORIZEDPARTIES_ADMIN })));
+            policy.Requirements.Add(new ScopeAccessRequirement(new string[] { AuthzConstants.SCOPE_AUTHORIZEDPARTIES_RESOURCEOWNER, AuthzConstants.SCOPE_AUTHORIZEDPARTIES_ADMIN })));
     });
 
     services.AddTransient<IAuthorizationHandler, ClaimAccessHandler>();

--- a/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
+++ b/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
@@ -379,17 +379,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for a person identified by urn:altinn:person:identifier-no
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPersonId() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId, Value = MainUnitAndSubUnitToOrg_ToOrgDaglPersonId },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
@@ -398,17 +398,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for a person identified by urn:altinn:person:uuid
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPersonUuid() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUuid, Value = MainUnitAndSubUnitToOrg_ToOrgDaglPersonUuid },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
@@ -417,17 +417,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for a person identified by urn:altinn:partyid
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPartyId() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgDaglPartyId.ToString() },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
@@ -436,17 +436,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for a person identified by urn:altinn:userid
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByUserId() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgDaglUserId.ToString() },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
@@ -455,17 +455,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:organization:identifier-no
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByOrganizationNumber() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationId, Value = MainUnitAndSubUnitToOrg_ToOrgOrganizationNumber },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetOrgList", BothAltinn3AndAltinn2)
@@ -474,17 +474,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:organization:uuid
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByOrganizationUuid() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationUuid, Value = MainUnitAndSubUnitToOrg_ToOrgOrganizationUuid },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetOrgList", BothAltinn3AndAltinn2)
@@ -493,17 +493,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:partyid
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByPartyId() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgPartyId.ToString() },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetOrgList", BothAltinn3AndAltinn2)
@@ -512,17 +512,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:enterpriseuser:username
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUsername() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName, Value = MainUnitAndSubUnitToOrg_ToOrgEcKeyRoleUsername },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetEnterpriseUserList", BothAltinn3AndAltinn2)
@@ -531,17 +531,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:enterpriseuser:uuid
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUuid() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserUuid, Value = MainUnitAndSubUnitToOrg_ToOrgEcKeyRoleUserUuid },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetEnterpriseUserList", BothAltinn3AndAltinn2)
@@ -550,17 +550,17 @@ public static class TestDataAuthorizedParties
 
     /// <summary>
     /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}
-    ///             with a valid resource owner token with the scope: altinn:resourceowner/authorizedparties
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:userid
     /// Expected:   - Should return 200 OK
     ///             - Should include expected authorized party list of the requested party
-    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:resourceowner/authorizedparties
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
     public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByUserId() => new()
     {
         {
-            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:resourceowner/authorizedparties"),
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgEcKeyRoleUserId.ToString() },
             true,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetEnterpriseUserList", BothAltinn3AndAltinn2)


### PR DESCRIPTION
## Description
Update to scope requirement for AuthorizedParties API for resource owners

Scope requirement changed to:

`altinn:accessmanagement/authorizedparties.resourceowner`
- gives access to lookup authorized parties of any third party where the third party have access to any of the resource owners apps or resources

`altinn:accessmanagement/authorizedparties.admin`
- gives access to lookup authorized parties of any third party across all resource owners apps and resources. Only given to select partners.

## Related Issue(s)
- #563

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [x] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
