### PR TITLE
Bruno manual requests update

### DIFF
--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Kasper TT02.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Kasper TT02.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Kasper TT02
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=true
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 55899
+  auth_partyId: 50027004
+  auth_ssn: '07125602120'
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Ostekake TT02.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Ostekake TT02.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Ostekake TT02
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=false
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: false
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 341548
+  auth_partyId: 52127981
+  auth_ssn: '15923648388'
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Ostekake.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Ostekake.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Ostekake
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=false
+  body: json
+  auth: none
+}
+
+query {
+  includeAltinn2: false
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+vars:pre-request {
+  auth_tokenType: Personal
+  auth_userId: 20009645
+  auth_partyId: 51221245
+  auth_ssn: '15923648388'
+}
+
+script:pre-request {
+  await tokenGenerator.getToken();
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Prod.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsAuthenticatedUser/Prod.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Prod
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/accessmanagement/api/v1/authorizedparties?includeAltinn2=true
+  body: json
+  auth: bearer
+}
+
+query {
+  includeAltinn2: true
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+}
+
+auth:bearer {
+  token: {{ProdToken}}
+}
+
+tests {
+  test("Should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByNationalIdentity.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByNationalIdentity.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByPartyId.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByPartyId.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByUserId.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/KasperByUserId.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUsername.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUsername.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUuid.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/OrstaECUserByUuid.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByOrgNo.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByOrgNo.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByPartyId.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByPartyId.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByUuid.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/AuthorizedParties/AsServiceOwner/ØrstaByUuid.bru
@@ -30,7 +30,7 @@ vars:pre-request {
   auth_tokenType: Enterprise
   auth_org: digdir
   auth_orgNo: 991825827
-  auth_scopes: altinn:resourceowner/authorizedparties
+  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Karlstad for MainUnit.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Karlstad for MainUnit.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Karlstad for MainUnit
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/policyinformation/getdelegationchanges
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "subject": {
+      "id": "urn:altinn:partyid",
+      "value": "50004222"
+    },
+    "party": {
+      "id": "urn:altinn:partyid",
+      "value": "50006037"
+    },
+    "resource": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "devtest_gar_authparties-main-to-org"
+      }
+    ]
+  }
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Karlstad for Ørsta.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Karlstad for Ørsta.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Karlstad for Ørsta
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/policyinformation/getdelegationchanges
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "subject": {
+      "id": "urn:altinn:partyid",
+      "value": "50004222"
+    },
+    "party": {
+      "id": "urn:altinn:partyid",
+      "value": "50005545"
+    },
+    "resource": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "test-ressurs-rf-1086-altinn-autorisasjon"
+      }
+    ]
+  }
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Paula for MainUnit.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Paula for MainUnit.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Paula for MainUnit
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/policyinformation/getdelegationchanges
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "subject": {
+      "id": "urn:altinn:userid",
+      "value": "20000095"
+    },
+    "party": {
+      "id": "urn:altinn:partyid",
+      "value": "50006037"
+    },
+    "resource": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "devtest_gar_authparties-main-to-org"
+      }
+    ]
+  }
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Paula for Ørsta.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/PolicyInformationPoint/GetDelegationChanges/Paula for Ørsta.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Paula for Ørsta
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/accessmanagement/api/v1/policyinformation/getdelegationchanges
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "subject": {
+      "id": "urn:altinn:userid",
+      "value": "20000095"
+    },
+    "party": {
+      "id": "urn:altinn:partyid",
+      "value": "50005545"
+    },
+    "resource": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "test-ressurs-rf-1086-altinn-autorisasjon"
+      }
+    ]
+  }
+}

--- a/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to Ostekake.bru
+++ b/test/Bruno/Altinn.AccessManagement/Manual Test Collection/RightsInternal/ClearAccessCache/Ørsta to Ostekake.bru
@@ -1,17 +1,13 @@
 meta {
-  name: KasperByUuid
+  name: Ørsta to Ostekake
   type: http
-  seq: 5
+  seq: 4
 }
 
-post {
-  url: {{baseUrl}}/accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2=true
+put {
+  url: {{baseUrl}}/accessmanagement/api/v1/internal/50005545/accesscache/clear
   body: json
   auth: none
-}
-
-query {
-  includeAltinn2: true
 }
 
 headers {
@@ -22,15 +18,15 @@ headers {
 body:json {
   {
     "type": "urn:altinn:person:uuid",
-    "value": "ee007db6-0db4-4e55-ac21-2a888f04d846"
+    "value": "88bc3eff-bed2-46fe-8dd8-64dce1f94691"
   }
 }
 
 vars:pre-request {
-  auth_tokenType: Enterprise
-  auth_org: digdir
-  auth_orgNo: 991825827
-  auth_scopes: altinn:accessmanagement/authorizedparties.resourceowner
+  auth_tokenType: Personal
+  auth_userId: 20000490
+  auth_partyId: 50002598
+  auth_ssn: '07124912037'
 }
 
 script:pre-request {

--- a/test/Bruno/Altinn.AccessManagement/environments/PROD.bru
+++ b/test/Bruno/Altinn.AccessManagement/environments/PROD.bru
@@ -1,3 +1,6 @@
 vars {
   baseUrl: https://platform.altinn.no
 }
+vars:secret [
+  ProdToken
+]


### PR DESCRIPTION
- Updated ResourceOwner AuthorizedParties requests for updated Scope requirement
- Added some of my lokal requests used for testing various scenarios not already covered e.g
-- Cache clearing
-- TT02 requests having different user/party identifiers
-- Prod requests using prod token as env secret
