### PR TITLE
AuthorizedParties | Include authorized resources through roles

### DIFF
--- a/src/Altinn.AccessManagement.Core/Clients/Interfaces/IResourceRegistryClient.cs
+++ b/src/Altinn.AccessManagement.Core/Clients/Interfaces/IResourceRegistryClient.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.AccessManagement.Core.Models.ResourceRegistry;
+using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Core.Clients.Interfaces
 {
@@ -28,5 +29,13 @@ namespace Altinn.AccessManagement.Core.Clients.Interfaces
         /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
         /// <returns>The resource full list of all resources if exists</returns>
         Task<List<ServiceResource>> GetResourceList(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Integration point for retrieving all resources having any of the request subjects in one or more resource policy rules
+        /// </summary>
+        /// <param name="subjects">Urn string representation of the subjects to lookup resources for</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+        /// <returns>Dictionary of all resources per subject, having policy rules with the subject</returns>
+        Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Altinn.AccessManagement.Core/Clients/Interfaces/IResourceRegistryClient.cs
+++ b/src/Altinn.AccessManagement.Core/Clients/Interfaces/IResourceRegistryClient.cs
@@ -1,5 +1,5 @@
-﻿using Altinn.AccessManagement.Core.Models.ResourceRegistry;
-using Altinn.AccessManagement.Models;
+﻿using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 
 namespace Altinn.AccessManagement.Core.Clients.Interfaces
 {

--- a/src/Altinn.AccessManagement.Core/Configuration/CacheConfig.cs
+++ b/src/Altinn.AccessManagement.Core/Configuration/CacheConfig.cs
@@ -36,6 +36,11 @@ namespace Altinn.AccessManagement.Core.Configuration
         public int ResourceRegistryResourceCacheTimeout { get; set; }
 
         /// <summary>
+        /// Gets or sets the cache timeout (in minutes) for lookup of a subject resources from the resourceregistry
+        /// </summary>
+        public int ResourceRegistrySubjectResourcesCacheTimeout { get; set; }
+
+        /// <summary>
         /// Gets or sets the cache timeout (in minutes) for lookup of a rights
         /// </summary>
         public int RightsCacheTimeout { get; set; }        

--- a/src/Altinn.AccessManagement.Core/Models/BaseAttribute.cs
+++ b/src/Altinn.AccessManagement.Core/Models/BaseAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Altinn.AccessManagement.Models;
+namespace Altinn.AccessManagement.Core.Models;
 
 /// <summary>
 /// This model describes a an Attribute consisting of an Attribute Type and Attribute Value which can also be represented as a Urn by combining the properties as '{type}:{value}'

--- a/src/Altinn.AccessManagement.Core/Models/ListObjectResult.cs
+++ b/src/Altinn.AccessManagement.Core/Models/ListObjectResult.cs
@@ -2,7 +2,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Altinn.AccessManagement.Models;
+namespace Altinn.AccessManagement.Core.Models;
 
 /// <summary>
 /// A list object is a wrapper around a list of items to allow for the API to be

--- a/src/Altinn.AccessManagement.Core/Models/ListObjectResult.cs
+++ b/src/Altinn.AccessManagement.Core/Models/ListObjectResult.cs
@@ -1,0 +1,23 @@
+﻿#nullable enable
+
+using System.Text.Json.Serialization;
+
+namespace Altinn.AccessManagement.Models;
+
+/// <summary>
+/// A list object is a wrapper around a list of items to allow for the API to be
+/// extended in the future without breaking backwards compatibility.
+/// </summary>
+public abstract record ListObjectResult
+{
+}
+
+/// <summary>
+/// A concrete list object.
+/// </summary>
+/// <typeparam name="T">The item type.</typeparam>
+/// <param name="Items">The items.</param>
+public record ListObjectResult<T>(
+    [property: JsonPropertyName("data")]
+    IEnumerable<T> Items)
+    : ListObjectResult;

--- a/src/Altinn.AccessManagement.Core/Models/PaginatedResult.cs
+++ b/src/Altinn.AccessManagement.Core/Models/PaginatedResult.cs
@@ -1,0 +1,39 @@
+﻿#nullable enable
+
+namespace Altinn.AccessManagement.Models;
+
+/// <summary>
+/// A paginated <see cref="ListObjectResult{T}"/>.
+/// </summary>
+public static class PaginatedResult
+{
+    /// <summary>
+    /// Create a new <see cref="PaginatedResult{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of items</typeparam>
+    /// <param name="items">The items</param>
+    /// <param name="next">The optional next-link</param>
+    /// <returns>A new <see cref="PaginatedResult{T}"/>.</returns>
+    public static PaginatedResult<T> Create<T>(
+        IEnumerable<T> items,
+        string? next)
+        => new(new(next), items);
+}
+
+/// <summary>
+/// A paginated <see cref="ListObjectResult{T}"/>.
+/// </summary>
+/// <typeparam name="T">The item type.</typeparam>
+/// <param name="Links">Pagination links.</param>
+/// <param name="Items">The items.</param>
+public record PaginatedResult<T>(
+    PaginatedResultLinks Links,
+    IEnumerable<T> Items)
+    : ListObjectResult<T>(Items);
+
+/// <summary>
+/// Pagination links.
+/// </summary>
+/// <param name="Next">Link to the next page of items (if any).</param>
+public record PaginatedResultLinks(
+    string? Next);

--- a/src/Altinn.AccessManagement.Core/Models/PaginatedResult.cs
+++ b/src/Altinn.AccessManagement.Core/Models/PaginatedResult.cs
@@ -1,6 +1,6 @@
 ﻿#nullable enable
 
-namespace Altinn.AccessManagement.Models;
+namespace Altinn.AccessManagement.Core.Models;
 
 /// <summary>
 /// A paginated <see cref="ListObjectResult{T}"/>.

--- a/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/SubjectResources.cs
+++ b/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/SubjectResources.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+using Altinn.AccessManagement.Models;
+
+namespace Altinn.AccessManagement.Core.Models.ResourceRegistry
+{
+    /// <summary>
+    /// Defines resources that a given subject have access to
+    /// </summary>
+    public class SubjectResources
+    {
+        /// <summary>
+        /// The subject
+        /// </summary>
+        public required BaseAttribute Subject { get; set; }    
+
+        /// <summary>
+        /// List of resources that the given subject has access to
+        /// </summary>
+        public required IEnumerable<BaseAttribute> Resources { get; set; }
+    }
+}

--- a/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/SubjectResources.cs
+++ b/src/Altinn.AccessManagement.Core/Models/ResourceRegistry/SubjectResources.cs
@@ -1,21 +1,18 @@
 ﻿#nullable enable
-using Altinn.AccessManagement.Models;
+namespace Altinn.AccessManagement.Core.Models.ResourceRegistry;
 
-namespace Altinn.AccessManagement.Core.Models.ResourceRegistry
+/// <summary>
+/// Defines resources that a given subject have access to
+/// </summary>
+public class SubjectResources
 {
     /// <summary>
-    /// Defines resources that a given subject have access to
+    /// The subject
     /// </summary>
-    public class SubjectResources
-    {
-        /// <summary>
-        /// The subject
-        /// </summary>
-        public required BaseAttribute Subject { get; set; }    
+    public required BaseAttribute Subject { get; set; }    
 
-        /// <summary>
-        /// List of resources that the given subject has access to
-        /// </summary>
-        public required IEnumerable<BaseAttribute> Resources { get; set; }
-    }
+    /// <summary>
+    /// List of resources that the given subject has access to
+    /// </summary>
+    public required IEnumerable<BaseAttribute> Resources { get; set; }
 }

--- a/src/Altinn.AccessManagement.Core/Services/Altinn2RightsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Altinn2RightsService.cs
@@ -1,9 +1,7 @@
-using System.Runtime.Versioning;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Constants;
 using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Services.Interfaces;
-using Altinn.AccessManagement.Models;
 using Altinn.Platform.Register.Enums;
 
 namespace Altinn.AccessManagement.Core.Services;

--- a/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
@@ -37,21 +37,21 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedParties(BaseAttribute subjectAttribute, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken) => subjectAttribute.Type switch
+    public async Task<List<AuthorizedParty>> GetAuthorizedParties(BaseAttribute subjectAttribute, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken) => subjectAttribute.Type switch
     {
-        AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId => await GetAuthorizedPartiesForPerson(subjectAttribute.Value.ToString(), includeAltinn2AuthorizedParties, cancellationToken),
-        AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationId => await GetAuthorizedPartiesForOrganization(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
-        AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName => await GetAuthorizedPartiesForEnterpriseUser(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
-        AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUuid => await GetAuthorizedPartiesForPersonUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
-        AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationUuid => await GetAuthorizedPartiesForOrganizationUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
-        AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserUuid => await GetAuthorizedPartiesForEnterpriseUserUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, cancellationToken),
-        AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute => await GetAuthorizedPartiesForParty(int.Parse(subjectAttribute.Value), includeAltinn2AuthorizedParties, cancellationToken),
-        AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute => await GetAuthorizedPartiesForUser(int.Parse(subjectAttribute.Value), includeAltinn2AuthorizedParties, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId => await GetAuthorizedPartiesForPerson(subjectAttribute.Value.ToString(), includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationId => await GetAuthorizedPartiesForOrganization(subjectAttribute.Value, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName => await GetAuthorizedPartiesForEnterpriseUser(subjectAttribute.Value, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUuid => await GetAuthorizedPartiesForPersonUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationUuid => await GetAuthorizedPartiesForOrganizationUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserUuid => await GetAuthorizedPartiesForEnterpriseUserUuid(subjectAttribute.Value, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute => await GetAuthorizedPartiesForParty(int.Parse(subjectAttribute.Value), includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
+        AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute => await GetAuthorizedPartiesForUser(int.Parse(subjectAttribute.Value), includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken),
         _ => throw new ArgumentException(message: $"Unknown attribute type: {subjectAttribute.Type}", paramName: nameof(subjectAttribute))
     };
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForParty(int subjectPartyId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForParty(int subjectPartyId, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         Party subject = await _contextRetrievalService.GetPartyAsync(subjectPartyId, cancellationToken);
         if (subject?.PartyTypeName == PartyType.Person)
@@ -59,39 +59,39 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
             UserProfile user = await _profile.GetUser(new() { Ssn = subject.SSN }, cancellationToken);
             if (user != null)
             {
-                return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+                return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
             }
         }
 
         if (subject?.PartyTypeName == PartyType.Organisation)
         {
-            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, cancellationToken);
+            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
         }
 
         return await Task.FromResult(new List<AuthorizedParty>());
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForUser(int subjectUserId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForUser(int subjectUserId, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         List<int> keyRoleUnits = await _contextRetrievalService.GetKeyRolePartyIds(subjectUserId, cancellationToken);
-        return await BuildAuthorizedParties(subjectUserId, keyRoleUnits, includeAltinn2AuthorizedParties, cancellationToken);
+        return await BuildAuthorizedParties(subjectUserId, keyRoleUnits, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForPerson(string subjectNationalId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForPerson(string subjectNationalId, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         UserProfile user = await _profile.GetUser(new() { Ssn = subjectNationalId }, cancellationToken);
         if (user != null)
         {
-            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
         }
 
         return await Task.FromResult(new List<AuthorizedParty>());
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForPersonUuid(string subjectPersonUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForPersonUuid(string subjectPersonUuid, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         if (!Guid.TryParse(subjectPersonUuid, out Guid personUuid))
         {
@@ -101,26 +101,26 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
         UserProfile user = await _profile.GetUser(new() { UserUuid = personUuid }, cancellationToken);
         if (user != null && user.Party.PartyTypeName == PartyType.Person)
         {
-            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
         }
 
         return await Task.FromResult(new List<AuthorizedParty>());
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganization(string subjectOrganizationNumber, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganization(string subjectOrganizationNumber, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         Party subject = await _contextRetrievalService.GetPartyForOrganization(subjectOrganizationNumber, cancellationToken);
         if (subject != null)
         {
-            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, cancellationToken);
+            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
         }
 
         return await Task.FromResult(new List<AuthorizedParty>());
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganizationUuid(string subjectOrganizationUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganizationUuid(string subjectOrganizationUuid, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         if (!Guid.TryParse(subjectOrganizationUuid, out Guid orgUuid))
         {
@@ -130,26 +130,26 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
         Party subject = await _contextRetrievalService.GetPartyByUuid(orgUuid, cancellationToken: cancellationToken);
         if (subject != null && subject.PartyTypeName == PartyType.Organisation)
         {
-            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, cancellationToken);
+            return await BuildAuthorizedParties(0, subject.PartyId.SingleToList(), includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
         }
 
         return await Task.FromResult(new List<AuthorizedParty>());
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUser(string subjectEnterpriseUsername, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUser(string subjectEnterpriseUsername, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         UserProfile user = await _profile.GetUser(new() { Username = subjectEnterpriseUsername }, cancellationToken);
         if (user != null && user.Party.PartyTypeName == PartyType.Organisation)
         {
-            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
         }
 
         return await Task.FromResult(new List<AuthorizedParty>());
     }
 
     /// <inheritdoc/>
-    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUserUuid(string subjectEnterpriseUserUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    public async Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUserUuid(string subjectEnterpriseUserUuid, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken)
     {
         if (!Guid.TryParse(subjectEnterpriseUserUuid, out Guid enterpriseUserUuid))
         {
@@ -159,24 +159,29 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
         UserProfile user = await _profile.GetUser(new() { UserUuid = enterpriseUserUuid }, cancellationToken);
         if (user != null && user.Party.PartyTypeName == PartyType.Organisation)
         {
-            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, cancellationToken);
+            return await GetAuthorizedPartiesForUser(user.UserId, includeAltinn2AuthorizedParties, includeAuthorizedResourcesThroughRoles, cancellationToken);
         }
 
         return await Task.FromResult(new List<AuthorizedParty>());
     }
 
-    private async Task<List<AuthorizedParty>> BuildAuthorizedParties(int subjectUserId, List<int> subjectPartyIds, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken)
+    private async Task<List<AuthorizedParty>> BuildAuthorizedParties(int subjectUserId, List<int> subjectPartyIds, bool includeAltinn2AuthorizedParties, bool includeResourcesThroughRoles, CancellationToken cancellationToken)
     {
         List<AuthorizedParty> result = new();
         List<AuthorizedParty> a3AuthParties = new();
         SortedDictionary<int, AuthorizedParty> authorizedPartyDict = [];
         SortedDictionary<int, List<string>> authorizedResourcesDict = [];
 
-        if (includeAltinn2AuthorizedParties && subjectUserId != 0)
+        if ((includeAltinn2AuthorizedParties || includeResourcesThroughRoles) && subjectUserId != 0)
         {
             List<AuthorizedParty> a2AuthParties = await _altinnRolesClient.GetAuthorizedPartiesWithRoles(subjectUserId, cancellationToken);
             foreach (AuthorizedParty a2AuthParty in a2AuthParties)
             {
+                if (includeResourcesThroughRoles)
+                {
+                    await EnrichPartyWithAuthorizedResourcesThroughRoles(a2AuthParty, cancellationToken);
+                }
+
                 authorizedPartyDict.Add(a2AuthParty.PartyId, a2AuthParty);
                 if (a2AuthParty.Subunits != null)
                 {
@@ -189,8 +194,6 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
 
             result = a2AuthParties;
         }
-
-        //// To-be-implemented: Find all authorized resources through roles (needs RR Role - Resource API)
 
         List<DelegationChange> delegations = await _delegations.GetAllDelegationChangesForAuthorizedParties(subjectUserId != 0 ? subjectUserId.SingleToList() : null, subjectPartyIds, cancellationToken: cancellationToken);
 
@@ -286,5 +289,22 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
 
         result.AddRange(a3AuthParties);
         return result;
+    }
+
+    private async Task EnrichPartyWithAuthorizedResourcesThroughRoles(AuthorizedParty party, CancellationToken cancellationToken)
+    {
+        if (party.AuthorizedRoles?.Count > 0)
+        {
+            IDictionary<string, IEnumerable<BaseAttribute>> subjectResources = await _contextRetrievalService.GetSubjectResources(party.AuthorizedRoles.Select(r => $"{AltinnXacmlConstants.MatchAttributeIdentifiers.RoleAttribute}:{r.ToLower()}"), cancellationToken);
+            party.AuthorizedResources.AddRange(subjectResources.Keys.SelectMany(subject => subjectResources[subject].Where(resource => resource != null && resource.Value != null).Select(resource => resource.Value)));
+        }
+
+        if (party.Subunits?.Count > 0)
+        {
+            foreach (AuthorizedParty subunit in party.Subunits)
+            {
+                await EnrichPartyWithAuthorizedResourcesThroughRoles(subunit, cancellationToken);
+            }
+        }
     }
 }

--- a/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
@@ -170,7 +170,6 @@ public class AuthorizedPartiesService : IAuthorizedPartiesService
         List<AuthorizedParty> result = new();
         List<AuthorizedParty> a3AuthParties = new();
         SortedDictionary<int, AuthorizedParty> authorizedPartyDict = [];
-        SortedDictionary<int, List<string>> authorizedResourcesDict = [];
 
         if ((includeAltinn2AuthorizedParties || includeResourcesThroughRoles) && subjectUserId != 0)
         {

--- a/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/AuthorizedPartiesService.cs
@@ -6,7 +6,6 @@ using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.SblBridge;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Core.Services.Interfaces;
-using Altinn.AccessManagement.Models;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;

--- a/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
@@ -1,10 +1,10 @@
 using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Configuration;
 using Altinn.AccessManagement.Core.Helpers.Extensions;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Models.SblBridge;
 using Altinn.AccessManagement.Core.Services.Interfaces;
-using Altinn.AccessManagement.Models;
 using Altinn.Platform.Register.Models;
 using Authorization.Platform.Authorization.Models;
 using Microsoft.Extensions.Caching.Memory;

--- a/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/ContextRetrievalService.cs
@@ -444,7 +444,7 @@ public class ContextRetrievalService : IContextRetrievalService
     /// <inheritdoc/>
     public async Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default)
     {
-        IDictionary<string, IEnumerable<BaseAttribute>> subjectResources = new Dictionary<string, IEnumerable<BaseAttribute>>();
+        Dictionary<string, IEnumerable<BaseAttribute>> subjectResources = new Dictionary<string, IEnumerable<BaseAttribute>>();
         List<string> subjectKeysNotInCache = new List<string>();
 
         foreach (string subjectKey in subjects.Distinct())

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IAltinn2RightsService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IAltinn2RightsService.cs
@@ -1,5 +1,4 @@
 using Altinn.AccessManagement.Core.Models;
-using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Core.Services.Interfaces;
 

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IAuthorizedPartiesService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IAuthorizedPartiesService.cs
@@ -13,79 +13,88 @@ public interface IAuthorizedPartiesService
     /// </summary>
     /// <param name="subjectAttribute">Attribute identifying the user or organization retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedParties(BaseAttribute subjectAttribute, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedParties(BaseAttribute subjectAttribute, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given user can represent in Altinn
     /// </summary>
     /// <param name="subjectUserId">The user id of the user to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForUser(int subjectUserId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForUser(int subjectUserId, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given user or organization have some access for in Altinn
     /// </summary>
     /// <param name="subjectPartyId">The party id of the user or organization to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForParty(int subjectPartyId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForParty(int subjectPartyId, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given person can represent in Altinn
     /// </summary>
     /// <param name="subjectNationalId">The national identity number of the person to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForPerson(string subjectNationalId, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForPerson(string subjectNationalId, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given person can represent in Altinn
     /// </summary>
     /// <param name="subjectPersonUuid">The uuid of the person to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForPersonUuid(string subjectPersonUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForPersonUuid(string subjectPersonUuid, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given organization can represent in Altinn
     /// </summary>
     /// <param name="subjectOrganizationNumber">The organization number of the organization to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganization(string subjectOrganizationNumber, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganization(string subjectOrganizationNumber, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given organization can represent in Altinn
     /// </summary>
     /// <param name="subjectOrganizationUuid">The organization uuid of the organization to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganizationUuid(string subjectOrganizationUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForOrganizationUuid(string subjectOrganizationUuid, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given enterprise user can represent in Altinn
     /// </summary>
     /// <param name="subjectEnterpriseUsername">The username of the enterprise user to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUser(string subjectEnterpriseUsername, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUser(string subjectEnterpriseUsername, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the full unfiltered list of authorized parties the given enterprise user can represent in Altinn
     /// </summary>
     /// <param name="subjectEnterpriseUserUuid">The uuid of the enterprise user to retrieve the authorized party list for</param>
     /// <param name="includeAltinn2AuthorizedParties">Whether Authorized Parties from Altinn 2 should be included in the result set</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>The unfiltered party list</returns>
-    Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUserUuid(string subjectEnterpriseUserUuid, bool includeAltinn2AuthorizedParties, CancellationToken cancellationToken);
+    Task<List<AuthorizedParty>> GetAuthorizedPartiesForEnterpriseUserUuid(string subjectEnterpriseUserUuid, bool includeAltinn2AuthorizedParties, bool includeAuthorizedResourcesThroughRoles, CancellationToken cancellationToken);
 }

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IAuthorizedPartiesService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IAuthorizedPartiesService.cs
@@ -1,5 +1,4 @@
 ﻿using Altinn.AccessManagement.Core.Models;
-using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Core.Services.Interfaces;
 

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IContextRetrievalService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IContextRetrievalService.cs
@@ -1,5 +1,6 @@
 ﻿using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Models.SblBridge;
+using Altinn.AccessManagement.Models;
 using Altinn.Platform.Register.Models;
 using Authorization.Platform.Authorization.Models;
 
@@ -155,4 +156,12 @@ public interface IContextRetrievalService
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <returns>Party that corresponds to partyId parameter if it's in the users reporteelist</returns>
     Task<Party> GetPartyForUser(int userId, int partyId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all resources having any of the request subjects in one or more resource policy rules
+    /// </summary>
+    /// <param name="subjects">Urn string representation of the subjects to lookup resources for</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
+    /// <returns>Dictionary of all resources per subject, having policy rules with the subject</returns>
+    Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default);
 }

--- a/src/Altinn.AccessManagement.Core/Services/Interfaces/IContextRetrievalService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/Interfaces/IContextRetrievalService.cs
@@ -1,6 +1,6 @@
-﻿using Altinn.AccessManagement.Core.Models.ResourceRegistry;
+﻿using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Models.SblBridge;
-using Altinn.AccessManagement.Models;
 using Altinn.Platform.Register.Models;
 using Authorization.Platform.Authorization.Models;
 

--- a/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
+++ b/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
@@ -4,9 +4,9 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Integration.Configuration;
-using Altinn.AccessManagement.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
+++ b/src/Altinn.AccessManagement.Integration/Clients/ResourceRegistryClient.cs
@@ -106,7 +106,7 @@ namespace Altinn.AccessManagement.Integration.Clients
         public async Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default)
         {
             string endpointUrl = $"resource/bysubjects";
-            IDictionary<string, IEnumerable<BaseAttribute>> subjectResources = new Dictionary<string, IEnumerable<BaseAttribute>>();
+            Dictionary<string, IEnumerable<BaseAttribute>> subjectResources = new Dictionary<string, IEnumerable<BaseAttribute>>();
             StringContent requestBody = new StringContent(JsonSerializer.Serialize(subjects), Encoding.UTF8, "application/json");
 
             HttpResponseMessage response = await _httpClient.PostAsync(endpointUrl, requestBody, cancellationToken);

--- a/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
+++ b/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
@@ -72,7 +72,7 @@ public class AuthorizedPartiesController : ControllerBase
                 return Unauthorized();
             }
 
-            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, cancellationToken);
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, includeAuthorizedResourcesThroughRoles: false, cancellationToken);
 
             return _mapper.Map<List<AuthorizedPartyExternal>>(authorizedParties);
         }
@@ -112,7 +112,7 @@ public class AuthorizedPartiesController : ControllerBase
                 return Unauthorized();
             }
 
-            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, cancellationToken);
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForUser(userId, includeAltinn2, includeAuthorizedResourcesThroughRoles: false, cancellationToken);
             AuthorizedParty authorizedParty = authorizedParties.Find(ap => ap.PartyId == partyId && !ap.OnlyHierarchyElementWithNoAccess)
                 ?? authorizedParties.SelectMany(ap => ap.Subunits).FirstOrDefault(subunit => subunit.PartyId == partyId);
 
@@ -162,7 +162,7 @@ public class AuthorizedPartiesController : ControllerBase
                 return Forbid();
             }
 
-            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForParty(subject.PartyId, includeAltinn2, cancellationToken);
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedPartiesForParty(subject.PartyId, includeAltinn2, includeAuthorizedResourcesThroughRoles: false, cancellationToken);
 
             return _mapper.Map<List<AuthorizedPartyExternal>>(authorizedParties);
         }

--- a/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesController.cs
+++ b/src/Altinn.AccessManagement/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesController.cs
@@ -43,6 +43,7 @@ public class ResourceOwnerAuthorizedPartiesController : ControllerBase
     /// </summary>
     /// <param name="subject">Subject input model identifying the user or organization to retrieve the list of authorized parties for</param>
     /// <param name="includeAltinn2">Optional (Default: False): Whether Authorized Parties from Altinn 2 should be included in the result set, and if access to Altinn 3 resources through having Altinn 2 roles should be included.</param>
+    /// <param name="includeAuthorizedResourcesThroughRoles">Optional (Default: False): Whether Authorized Resources per party should be enriched with resources the user has access to through AuthorizedRoles</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/></param>
     /// <response code="200" cref="List{AuthorizedParty}">Ok</response>
     /// <response code="401">Unauthorized</response>
@@ -58,12 +59,12 @@ public class ResourceOwnerAuthorizedPartiesController : ControllerBase
     [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
     [FeatureGate(FeatureFlags.RightsDelegationApi)]
-    public async Task<ActionResult<List<AuthorizedPartyExternal>>> GetAuthorizedPartiesAsServiceOwner(BaseAttributeExternal subject, bool includeAltinn2 = false, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<List<AuthorizedPartyExternal>>> GetAuthorizedPartiesAsServiceOwner(BaseAttributeExternal subject, bool includeAltinn2 = false, bool includeAuthorizedResourcesThroughRoles = false, CancellationToken cancellationToken = default)
     {
         try
         {
             BaseAttribute subjectAttribute = _mapper.Map<BaseAttribute>(subject);
-            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedParties(subjectAttribute, includeAltinn2, cancellationToken);
+            List<AuthorizedParty> authorizedParties = await _authorizedPartiesService.GetAuthorizedParties(subjectAttribute, includeAltinn2, includeAuthorizedResourcesThroughRoles, cancellationToken);
 
             return _mapper.Map<List<AuthorizedPartyExternal>>(authorizedParties);
         }

--- a/src/Altinn.AccessManagement/appsettings.json
+++ b/src/Altinn.AccessManagement/appsettings.json
@@ -6,6 +6,7 @@
     "PartyCacheTimeout": 10,
     "PolicyCacheTimeout": 10,
     "ResourceRegistryResourceCacheTimeout": 10,
+    "ResourceRegistrySubjectResourcesCacheTimeout": 60,
     "RightsCacheTimeout": 5
   },
   "PlatformSettings": {

--- a/test/Altinn.AccessManagement.Tests/Contexts/MockContext.cs
+++ b/test/Altinn.AccessManagement.Tests/Contexts/MockContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Models.SblBridge;
 using Altinn.AccessManagement.Tests.Fixtures;
@@ -29,6 +30,11 @@ public class MockContext
     /// List of mock resources
     /// </summary>
     public List<ServiceResource> Resources { get; set; } = [];
+
+    /// <summary>
+    /// Dictionary of mock subject resources
+    /// </summary>
+    public IDictionary<string, IEnumerable<BaseAttribute>> SubjectResources { get; set; } = new Dictionary<string, IEnumerable<BaseAttribute>>();
 
     /// <summary>
     /// List of mock parties

--- a/test/Altinn.AccessManagement.Tests/Contexts/MockContext.cs
+++ b/test/Altinn.AccessManagement.Tests/Contexts/MockContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Models.SblBridge;
+using Altinn.AccessManagement.Models;
 using Altinn.AccessManagement.Tests.Fixtures;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
@@ -29,6 +30,11 @@ public class MockContext
     /// List of mock resources
     /// </summary>
     public List<ServiceResource> Resources { get; set; } = [];
+
+    /// <summary>
+    /// Dictionary of mock subject resources
+    /// </summary>
+    public IDictionary<string, IEnumerable<BaseAttribute>> SubjectResources { get; set; } = new Dictionary<string, IEnumerable<BaseAttribute>>();
 
     /// <summary>
     /// List of mock parties

--- a/test/Altinn.AccessManagement.Tests/Contexts/MockContext.cs
+++ b/test/Altinn.AccessManagement.Tests/Contexts/MockContext.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Models.SblBridge;
-using Altinn.AccessManagement.Models;
 using Altinn.AccessManagement.Tests.Fixtures;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
@@ -30,11 +29,6 @@ public class MockContext
     /// List of mock resources
     /// </summary>
     public List<ServiceResource> Resources { get; set; } = [];
-
-    /// <summary>
-    /// Dictionary of mock subject resources
-    /// </summary>
-    public IDictionary<string, IEnumerable<BaseAttribute>> SubjectResources { get; set; } = new Dictionary<string, IEnumerable<BaseAttribute>>();
 
     /// <summary>
     /// List of mock parties

--- a/test/Altinn.AccessManagement.Tests/Contexts/ResourceRegistryMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Contexts/ResourceRegistryMock.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
-using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Tests.Contexts;
 

--- a/test/Altinn.AccessManagement.Tests/Contexts/ResourceRegistryMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Contexts/ResourceRegistryMock.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
+using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Tests.Contexts;
 
@@ -25,4 +26,8 @@ public class ResourceRegistryMock(MockContext context) : IResourceRegistryClient
     /// <inheritdoc/>
     public Task<List<ServiceResource>> GetResources(CancellationToken cancellationToken = default) =>
         Task.FromResult(Context.Resources);
+
+    /// <inheritdoc/>
+    public Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default) =>
+        Task.FromResult(Context.SubjectResources);
 }

--- a/test/Altinn.AccessManagement.Tests/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesControllerTest.cs
@@ -95,18 +95,23 @@ public class ResourceOwnerAuthorizedPartiesControllerTest : IClassFixture<Custom
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetPersonList_ByPersonUuid), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetPersonList_ByPartyId), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetPersonList_ByUserId), MemberType = typeof(TestDataAuthorizedParties))]
+    [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetPersonList_ByPersonId_InclResourcesThroughRoles), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetOrgList_ByOrganizationNumber), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetOrgList_ByOrganizationUuid), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetOrgList_ByPartyId), MemberType = typeof(TestDataAuthorizedParties))]
+    [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetOrgList_ByOrganizationNumber_InclResourcesThroughRoles), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUsername), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUuid), MemberType = typeof(TestDataAuthorizedParties))]
     [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetEnterpriseUserList_ByUserId), MemberType = typeof(TestDataAuthorizedParties))]
-    public async Task PostResourceOwnerAuthorizedParties_Ok(string resourceOwnerToken, BaseAttributeExternal attributeExt, bool inclA2, List<AuthorizedPartyExternal> expected)
+    [MemberData(nameof(TestDataAuthorizedParties.ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUsername_InclResourcesThroughRoles), MemberType = typeof(TestDataAuthorizedParties))]
+    public async Task PostResourceOwnerAuthorizedParties_Ok(string resourceOwnerToken, BaseAttributeExternal attributeExt, bool inclA2, bool inclRoleResources, List<AuthorizedPartyExternal> expected)
     {
         var client = GetTestClient(resourceOwnerToken);
 
         // Act
-        HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2={inclA2}", new StringContent(JsonSerializer.Serialize(attributeExt), Encoding.UTF8, MediaTypeNames.Application.Json));
+        HttpResponseMessage response = await client.PostAsync(
+            $"accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2={inclA2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}",
+            new StringContent(JsonSerializer.Serialize(attributeExt),Encoding.UTF8, MediaTypeNames.Application.Json));
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/test/Altinn.AccessManagement.Tests/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/ResourceOwnerAPI/ResourceOwnerAuthorizedPartiesControllerTest.cs
@@ -111,7 +111,7 @@ public class ResourceOwnerAuthorizedPartiesControllerTest : IClassFixture<Custom
         // Act
         HttpResponseMessage response = await client.PostAsync(
             $"accessmanagement/api/v1/resourceowner/authorizedparties?includeAltinn2={inclA2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}",
-            new StringContent(JsonSerializer.Serialize(attributeExt),Encoding.UTF8, MediaTypeNames.Application.Json));
+            new StringContent(JsonSerializer.Serialize(attributeExt), Encoding.UTF8, MediaTypeNames.Application.Json));
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
+++ b/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
@@ -23,6 +23,8 @@ public static class TestDataAuthorizedParties
 
     private static string BothAltinn3AndAltinn2 => "BothAltinn3AndAltinn2";
 
+    private static string InclResourcesThroughRoles => "InclResourcesThroughRoles";
+
     public static int PersonToPerson_FromUserId => 20100001;
 
     public static int PersonToPerson_FromPartyId => 50100001;
@@ -386,13 +388,35 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPersonId() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPersonId() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId, Value = MainUnitAndSubUnitToOrg_ToOrgDaglPersonId },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
+        }
+    };
+
+    /// <summary>
+    /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
+    ///             getting authorized party list for a person identified by urn:altinn:person:identifier-no
+    /// Expected:   - Should return 200 OK
+    ///             - Should include expected authorized party list of the requested party
+    ///             - Should include authorized resources the user has access to through roles for each authorized party
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
+    ///             are authorized to get authorized party list of any person, user or organization in Altinn
+    /// </summary>
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPersonId_InclResourcesThroughRoles() => new()
+    {
+        {
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
+            new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PersonId, Value = MainUnitAndSubUnitToOrg_ToOrgDaglPersonId },
+            false,
+            true,
+            GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", InclResourcesThroughRoles)
         }
     };
 
@@ -405,12 +429,13 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPersonUuid() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPersonUuid() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PersonUuid, Value = MainUnitAndSubUnitToOrg_ToOrgDaglPersonUuid },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
         }
     };
@@ -424,12 +449,13 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPartyId() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByPartyId() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgDaglPartyId.ToString() },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
         }
     };
@@ -443,12 +469,13 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByUserId() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetPersonList_ByUserId() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgDaglUserId.ToString() },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetPersonList", BothAltinn3AndAltinn2)
         }
     };
@@ -462,13 +489,35 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByOrganizationNumber() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByOrganizationNumber() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationId, Value = MainUnitAndSubUnitToOrg_ToOrgOrganizationNumber },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetOrgList", BothAltinn3AndAltinn2)
+        }
+    };
+
+    /// <summary>
+    /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
+    ///             getting authorized party list for an organization identified by urn:altinn:organization:identifier-no
+    /// Expected:   - Should return 200 OK
+    ///             - Should include expected authorized party list of the requested party
+    ///             - Should include authorized resources the user has access to through roles for each authorized party
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
+    ///             are authorized to get authorized party list of any person, user or organization in Altinn
+    /// </summary>
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByOrganizationNumber_InclResourcesThroughRoles() => new()
+    {
+        {
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
+            new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationId, Value = MainUnitAndSubUnitToOrg_ToOrgOrganizationNumber },
+            false,
+            true,
+            GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetOrgList", InclResourcesThroughRoles)
         }
     };
 
@@ -481,12 +530,13 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByOrganizationUuid() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByOrganizationUuid() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.OrganizationUuid, Value = MainUnitAndSubUnitToOrg_ToOrgOrganizationUuid },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetOrgList", BothAltinn3AndAltinn2)
         }
     };
@@ -500,12 +550,13 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByPartyId() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetOrgList_ByPartyId() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.PartyAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgPartyId.ToString() },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetOrgList", BothAltinn3AndAltinn2)
         }
     };
@@ -519,13 +570,35 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUsername() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUsername() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName, Value = MainUnitAndSubUnitToOrg_ToOrgEcKeyRoleUsername },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetEnterpriseUserList", BothAltinn3AndAltinn2)
+        }
+    };
+
+    /// <summary>
+    /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}
+    ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
+    ///             getting authorized party list for an organization identified by urn:altinn:enterpriseuser:username
+    /// Expected:   - Should return 200 OK
+    ///             - Should include expected authorized party list of the requested party
+    ///             - Should include authorized resources the user has access to through roles for each authorized party
+    /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
+    ///             are authorized to get authorized party list of any person, user or organization in Altinn
+    /// </summary>
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUsername_InclResourcesThroughRoles() => new()
+    {
+        {
+            PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
+            new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserName, Value = MainUnitAndSubUnitToOrg_ToOrgEcKeyRoleUsername },
+            false,
+            true,
+            GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetEnterpriseUserList", InclResourcesThroughRoles)
         }
     };
 
@@ -538,12 +611,13 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUuid() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByEnterpriseUserUuid() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.EnterpriseUserUuid, Value = MainUnitAndSubUnitToOrg_ToOrgEcKeyRoleUserUuid },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetEnterpriseUserList", BothAltinn3AndAltinn2)
         }
     };
@@ -557,12 +631,13 @@ public static class TestDataAuthorizedParties
     /// Reason:     Authenticated resource owner organizations authorized with scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             are authorized to get authorized party list of any person, user or organization in Altinn
     /// </summary>
-    public static TheoryData<string, BaseAttributeExternal, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByUserId() => new()
+    public static TheoryData<string, BaseAttributeExternal, bool, bool, List<AuthorizedPartyExternal>> ResourceOwner_GetEnterpriseUserList_ByUserId() => new()
     {
         {
             PrincipalUtil.GetOrgToken("digdir", "991825827", "altinn:accessmanagement/authorizedparties.resourceowner"),
             new BaseAttributeExternal { Type = AltinnXacmlConstants.MatchAttributeIdentifiers.UserAttribute, Value = MainUnitAndSubUnitToOrg_ToOrgEcKeyRoleUserId.ToString() },
             true,
+            false,
             GetExpectedResponse<List<AuthorizedPartyExternal>>("ResourceOwner_GetEnterpriseUserList", BothAltinn3AndAltinn2)
         }
     };

--- a/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
+++ b/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
@@ -8,6 +8,7 @@ using Altinn.AccessManagement.Tests.Util;
 using Altinn.AccessManagement.Tests.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
+using static System.Collections.Specialized.BitVector32;
 
 namespace Altinn.AccessManagement.Tests.Data;
 
@@ -400,7 +401,7 @@ public static class TestDataAuthorizedParties
     };
 
     /// <summary>
-    /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}
+    /// Test case:  <![CDATA[POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}]]>
     ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for a person identified by urn:altinn:person:identifier-no
     /// Expected:   - Should return 200 OK
@@ -501,7 +502,7 @@ public static class TestDataAuthorizedParties
     };
 
     /// <summary>
-    /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}
+    /// Test case:  <![CDATA[POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}]]>
     ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:organization:identifier-no
     /// Expected:   - Should return 200 OK
@@ -582,7 +583,7 @@ public static class TestDataAuthorizedParties
     };
 
     /// <summary>
-    /// Test case:  POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}
+    /// Test case:  <![CDATA[POST resourceowner/authorizedparties?includeAltinn2={includeAltinn2}&includeAuthorizedResourcesThroughRoles={inclRoleResources}]]>
     ///             with a valid resource owner token with the scope: altinn:accessmanagement/authorizedparties.resourceowner
     ///             getting authorized party list for an organization identified by urn:altinn:enterpriseuser:username
     /// Expected:   - Should return 200 OK

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetEnterpriseUserList/InclResourcesThroughRoles.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetEnterpriseUserList/InclResourcesThroughRoles.json
@@ -1,0 +1,69 @@
+[
+  {
+    "partyUuid": "00000000-0000-0000-0001-000000000010",
+    "name": "MAINUNIT AND SUBUNIT TO ORG RECIPIENT",
+    "organizationNumber": "901000010",
+    "personId": null,
+    "partyId": 50100010,
+    "type": "Organization",
+    "unitType": "AS",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "authorizedResources": [],
+    "authorizedRoles": [
+      "ECKEYROLE"
+    ],
+    "subunits": []
+  },
+  {
+    "partyUuid": "00000000-0000-0000-0001-000000000006",
+    "name": "AUTHORIZEDPARTIES MAINUNIT",
+    "organizationNumber": "901000006",
+    "personId": null,
+    "partyId": 50100006,
+    "type": "Organization",
+    "unitType": "AS",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "authorizedResources": [
+      "devtest_gar_authparties-main-to-org"
+    ],
+    "authorizedRoles": [],
+    "subunits": [
+      {
+        "partyUuid": "00000000-0000-0000-0001-000000000007",
+        "name": "AUTHORIZEDPARTIES SUBUNIT ONE",
+        "organizationNumber": "901000007",
+        "personId": null,
+        "partyId": 50100007,
+        "type": "Organization",
+        "unitType": "BEDR",
+        "isDeleted": false,
+        "onlyHierarchyElementWithNoAccess": false,
+        "authorizedResources": [
+          "app_ttd_am-devtest-sub-to-org",
+          "devtest_gar_authparties-main-to-org",
+          "devtest_gar_authparties-sub-to-org"
+        ],
+        "authorizedRoles": [],
+        "subunits": []
+      },
+      {
+        "partyUuid": "00000000-0000-0000-0001-000000000008",
+        "name": "AUTHORIZEDPARTIES SUBUNIT TWO",
+        "organizationNumber": "901000008",
+        "personId": null,
+        "partyId": 50100008,
+        "type": "Organization",
+        "unitType": "BEDR",
+        "isDeleted": false,
+        "onlyHierarchyElementWithNoAccess": false,
+        "authorizedResources": [
+          "devtest_gar_authparties-main-to-org"
+        ],
+        "authorizedRoles": [],
+        "subunits": []
+      }
+    ]
+  }
+]

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetOrgList/InclResourcesThroughRoles.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetOrgList/InclResourcesThroughRoles.json
@@ -1,0 +1,53 @@
+[
+  {
+    "partyUuid": "00000000-0000-0000-0001-000000000006",
+    "name": "AUTHORIZEDPARTIES MAINUNIT",
+    "organizationNumber": "901000006",
+    "personId": null,
+    "partyId": 50100006,
+    "type": "Organization",
+    "unitType": "AS",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "authorizedResources": [
+      "devtest_gar_authparties-main-to-org"
+    ],
+    "authorizedRoles": [],
+    "subunits": [
+      {
+        "partyUuid": "00000000-0000-0000-0001-000000000007",
+        "name": "AUTHORIZEDPARTIES SUBUNIT ONE",
+        "organizationNumber": "901000007",
+        "personId": null,
+        "partyId": 50100007,
+        "type": "Organization",
+        "unitType": "BEDR",
+        "isDeleted": false,
+        "onlyHierarchyElementWithNoAccess": false,
+        "authorizedResources": [
+          "app_ttd_am-devtest-sub-to-org",
+          "devtest_gar_authparties-main-to-org",
+          "devtest_gar_authparties-sub-to-org"
+        ],
+        "authorizedRoles": [],
+        "subunits": []
+      },
+      {
+        "partyUuid": "00000000-0000-0000-0001-000000000008",
+        "name": "AUTHORIZEDPARTIES SUBUNIT TWO",
+        "organizationNumber": "901000008",
+        "personId": null,
+        "partyId": 50100008,
+        "type": "Organization",
+        "unitType": "BEDR",
+        "isDeleted": false,
+        "onlyHierarchyElementWithNoAccess": false,
+        "authorizedResources": [
+          "devtest_gar_authparties-main-to-org"
+        ],
+        "authorizedRoles": [],
+        "subunits": []
+      }
+    ]
+  }
+]

--- a/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetPersonList/InclResourcesThroughRoles.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/AuthorizedParties/ResourceOwner_GetPersonList/InclResourcesThroughRoles.json
@@ -1,0 +1,84 @@
+[
+  {
+    "partyUuid": "00000000-0000-0000-0001-000000000011",
+    "name": "MAINUNIT AND SUBUNIT TO ORG DAGL",
+    "organizationNumber": null,
+    "personId": "01018170071",
+    "partyId": 50100011,
+    "type": "Person",
+    "unitType": null,
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "authorizedResources": [
+      "generic-access-resource"
+    ],
+    "authorizedRoles": [
+      "PRIV"
+    ],
+    "subunits": []
+  },
+  {
+    "partyUuid": "00000000-0000-0000-0001-000000000006",
+    "name": "AUTHORIZEDPARTIES MAINUNIT",
+    "organizationNumber": "901000006",
+    "personId": null,
+    "partyId": 50100006,
+    "type": "Organization",
+    "unitType": "AS",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "authorizedResources": [
+      "jks_audi_etron_gt",
+      "generic-access-resource",
+      "devtest_gar_authparties-main-to-org"
+    ],
+    "authorizedRoles": [
+      "UTINN"
+    ],
+    "subunits": [
+      {
+        "partyUuid": "00000000-0000-0000-0001-000000000007",
+        "name": "AUTHORIZEDPARTIES SUBUNIT ONE",
+        "organizationNumber": "901000007",
+        "personId": null,
+        "partyId": 50100007,
+        "type": "Organization",
+        "unitType": "BEDR",
+        "isDeleted": false,
+        "onlyHierarchyElementWithNoAccess": false,
+        "authorizedResources": [
+          "jks_audi_etron_gt",
+          "generic-access-resource",
+          "app_ttd_am-devtest-sub-to-org",
+          "devtest_gar_authparties-main-to-org",
+          "devtest_gar_authparties-sub-to-org"
+        ],
+        "authorizedRoles": [
+          "UTINN",
+          "APIADM"
+        ],
+        "subunits": []
+      },
+      {
+        "partyUuid": "00000000-0000-0000-0001-000000000008",
+        "name": "AUTHORIZEDPARTIES SUBUNIT TWO",
+        "organizationNumber": "901000008",
+        "personId": null,
+        "partyId": 50100008,
+        "type": "Organization",
+        "unitType": "BEDR",
+        "isDeleted": false,
+        "onlyHierarchyElementWithNoAccess": false,
+        "authorizedResources": [
+          "jks_audi_etron_gt",
+          "generic-access-resource",
+          "devtest_gar_authparties-main-to-org"
+        ],
+        "authorizedRoles": [
+          "UTINN"
+        ],
+        "subunits": []
+      }
+    ]
+  }
+]

--- a/test/Altinn.AccessManagement.Tests/Data/Resources/subjectResources.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Resources/subjectResources.json
@@ -1,0 +1,99 @@
+{
+  "links": {},
+  "data": [
+    {
+      "subject": {
+        "type": "urn:altinn:rolecode",
+        "value": "dagl",
+        "urn": "urn:altinn:rolecode:dagl"
+      },
+      "resources": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "app_ttd_apps-test",
+          "urn": "urn:altinn:resource:app_ttd_apps-test"
+        },
+        {
+          "type": "urn:altinn:resource",
+          "value": "generic-access-resource",
+          "urn": "urn:altinn:resource:generic-access-resource"
+        }
+      ]
+    },
+    {
+      "subject": {
+        "type": "urn:altinn:rolecode",
+        "value": "regna",
+        "urn": "urn:altinn:rolecode:regna"
+      },
+      "resources": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "app_ttd_apps-test",
+          "urn": "urn:altinn:resource:app_ttd_apps-test"
+        }
+      ]
+    },
+    {
+      "subject": {
+        "type": "urn:altinn:rolecode",
+        "value": "innh",
+        "urn": "urn:altinn:rolecode:innh"
+      },
+      "resources": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "jks_audi_etron_gt",
+          "urn": "urn:altinn:resource:jks_audi_etron_gt"
+        }
+      ]
+    },
+    {
+      "subject": {
+        "type": "urn:altinn:rolecode",
+        "value": "utinn",
+        "urn": "urn:altinn:rolecode:utinn"
+      },
+      "resources": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "jks_audi_etron_gt",
+          "urn": "urn:altinn:resource:jks_audi_etron_gt"
+        },
+        {
+          "type": "urn:altinn:resource",
+          "value": "generic-access-resource",
+          "urn": "urn:altinn:resource:generic-access-resource"
+        }
+      ]
+    },
+    {
+      "subject": {
+        "type": "urn:altinn:rolecode",
+        "value": "hadm",
+        "urn": "urn:altinn:rolecode:hadm"
+      },
+      "resources": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "jks_audi_etron_gt",
+          "urn": "urn:altinn:resource:jks_audi_etron_gt"
+        }
+      ]
+    },
+    {
+      "subject": {
+        "type": "urn:altinn:rolecode",
+        "value": "priv",
+        "urn": "urn:altinn:rolecode:priv"
+      },
+      "resources": [
+        {
+          "type": "urn:altinn:resource",
+          "value": "generic-access-resource",
+          "urn": "urn:altinn:resource:generic-access-resource"
+        }
+      ]
+    }
+  ]
+}

--- a/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,7 +76,19 @@ namespace Altinn.AccessManagement.Tests.Mocks
         /// <inheritdoc/>
         public Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            string content = File.ReadAllText($"Data/Resources/subjectResources.json");
+            PaginatedResult<SubjectResources> allSubjectResources = (PaginatedResult<SubjectResources>)JsonSerializer.Deserialize(content, typeof(PaginatedResult<SubjectResources>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            IDictionary<string, IEnumerable<BaseAttribute>> result = new Dictionary<string, IEnumerable<BaseAttribute>>();
+            if (allSubjectResources != null && allSubjectResources.Items != null)
+            {
+                foreach (SubjectResources resultItem in allSubjectResources.Items.Where(sr => subjects.Contains(sr.Subject.Urn)))
+                {
+                    result.Add(resultItem.Subject.Urn, resultItem.Resources);
+                }
+            }
+
+            return Task.FromResult(result);
         }
 
         private static string GetResourcePath(string resourceRegistryId)

--- a/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Integration.Clients;
+using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Tests.Mocks
 {
@@ -69,6 +70,12 @@ namespace Altinn.AccessManagement.Tests.Mocks
             List<ServiceResource> resources = (List<ServiceResource>)JsonSerializer.Deserialize(content, typeof(List<ServiceResource>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
             return Task.FromResult(resources);
+        }
+
+        /// <inheritdoc/>
+        public Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         private static string GetResourcePath(string resourceRegistryId)

--- a/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -6,9 +6,9 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Altinn.AccessManagement.Core.Clients.Interfaces;
+using Altinn.AccessManagement.Core.Models;
 using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Integration.Clients;
-using Altinn.AccessManagement.Models;
 
 namespace Altinn.AccessManagement.Tests.Mocks
 {

--- a/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
+++ b/test/Altinn.AccessManagement.Tests/Mocks/ResourceRegistryClientMock.cs
@@ -17,6 +17,8 @@ namespace Altinn.AccessManagement.Tests.Mocks
     /// </summary>
     public class ResourceRegistryClientMock : IResourceRegistryClient
     {
+        private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceRegistryClient"/> class
         /// </summary>
@@ -32,7 +34,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
             if (File.Exists(rolesPath))
             {
                 string content = File.ReadAllText(rolesPath);
-                resource = (ServiceResource)JsonSerializer.Deserialize(content, typeof(ServiceResource), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                resource = (ServiceResource)JsonSerializer.Deserialize(content, typeof(ServiceResource), _serializerOptions);
             }
 
             return await Task.FromResult(resource);
@@ -47,16 +49,12 @@ namespace Altinn.AccessManagement.Tests.Mocks
             if (Directory.Exists(path))
             {
                 string[] files = Directory.GetFiles(path);
-                var options = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                };
                 foreach (string file in files)
                 {
                     if (file.Contains("resources"))
                     {
                         string content = File.ReadAllText(Path.Combine(path, file));
-                        resources = JsonSerializer.Deserialize<List<ServiceResource>>(content, options);
+                        resources = JsonSerializer.Deserialize<List<ServiceResource>>(content, _serializerOptions);
                     }
                 }
             }
@@ -68,7 +66,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
         public Task<List<ServiceResource>> GetResourceList(CancellationToken cancellationToken = default)
         {
             string content = File.ReadAllText($"Data/Resources/resourceList.json");
-            List<ServiceResource> resources = (List<ServiceResource>)JsonSerializer.Deserialize(content, typeof(List<ServiceResource>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            List<ServiceResource> resources = (List<ServiceResource>)JsonSerializer.Deserialize(content, typeof(List<ServiceResource>), _serializerOptions);
 
             return Task.FromResult(resources);
         }
@@ -77,7 +75,7 @@ namespace Altinn.AccessManagement.Tests.Mocks
         public Task<IDictionary<string, IEnumerable<BaseAttribute>>> GetSubjectResources(IEnumerable<string> subjects, CancellationToken cancellationToken = default)
         {
             string content = File.ReadAllText($"Data/Resources/subjectResources.json");
-            PaginatedResult<SubjectResources> allSubjectResources = (PaginatedResult<SubjectResources>)JsonSerializer.Deserialize(content, typeof(PaginatedResult<SubjectResources>), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            PaginatedResult<SubjectResources> allSubjectResources = (PaginatedResult<SubjectResources>)JsonSerializer.Deserialize(content, typeof(PaginatedResult<SubjectResources>), _serializerOptions);
 
             IDictionary<string, IEnumerable<BaseAttribute>> result = new Dictionary<string, IEnumerable<BaseAttribute>>();
             if (allSubjectResources != null && allSubjectResources.Items != null)


### PR DESCRIPTION
## Description
- New query param for AuthorizedParties ResourceOwner API: includeAuthorizedResourcesThroughRoles
- New ResourceRegistryClient.GetSubjectResources implementation
- New ContextRetrievalService.GetSubjectResources  implementation with caching individual role subject resources
- AuthorizedPartiesService implementation updated with enrichment of AuthorizedResources per party based on AuthorizedRoles for the party

## Related Issue(s)
- #718

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
