### PR TITLE
Rewrite new Repo implementations away from Dapper

### DIFF
--- a/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IDelegationMetadataRepository.cs
+++ b/src/Altinn.AccessManagement.Core/Repositories/Interfaces/IDelegationMetadataRepository.cs
@@ -47,7 +47,7 @@ public interface IDelegationMetadataRepository
     /// <param name="coveredByPartyIds">The list of party id of the entity having received the delegated policy, if the entity is an organization</param>
     /// <param name="coveredByUserIds">The list of user id of the entity having received the delegated policy, if the entity is a user</param>
     /// <param name="cancellationToken">Cancellation token for cancelling the request</param>
-    Task<List<DelegationChange>> GetAllCurrentAppDelegationChanges(List<int> offeredByPartyIds, List<string> altinnAppIds = null, List<int> coveredByPartyIds = null, List<int> coveredByUserIds = null, CancellationToken cancellationToken = default);
+    Task<List<DelegationChange>> GetAllCurrentAppDelegationChanges(List<int> offeredByPartyIds, List<string> altinnAppIds, List<int> coveredByPartyIds = null, List<int> coveredByUserIds = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets all the current resource registry delegation change records matching the filter values

--- a/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
+++ b/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
@@ -628,7 +628,7 @@ namespace Altinn.AccessManagement.Persistence
             try
             {
                 await using var cmd = _conn.CreateCommand(query);
-                cmd.Parameters.AddWithValue("coveredByUserId",NpgsqlDbType.Integer, coveredByUserId);
+                cmd.Parameters.AddWithValue("coveredByUserId", NpgsqlDbType.Integer, coveredByUserId);
                 cmd.Parameters.AddWithNullableValue("resourceRegistryIds", NpgsqlDbType.Array | NpgsqlDbType.Text, resourceRegistryIds);
                 cmd.Parameters.AddWithNullableValue("resourceTypes", NpgsqlDbType.Array | NpgsqlDbType.Text, resourceTypes != null ? resourceTypes.Select(t => t.ToString().ToLower()).ToList() : null);
                 cmd.Parameters.AddWithNullableValue("offeredByPartyIds", NpgsqlDbType.Array | NpgsqlDbType.Integer, offeredByPartyIds);

--- a/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
+++ b/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
@@ -37,8 +37,8 @@ namespace Altinn.AccessManagement.Persistence
             
             if (coveredByUserId == null && coveredByPartyId == null)
             {
-                activity?.StopWithError(new ArgumentNullException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null."));
-                throw new ArgumentNullException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null.");
+                activity?.StopWithError(new ArgumentException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null."));
+                throw new ArgumentException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null.");
             }
 
             string query = string.Empty;
@@ -101,8 +101,8 @@ namespace Altinn.AccessManagement.Persistence
 
             if (coveredByPartyIds == null && coveredByUserIds == null)
             {
-                activity?.StopWithError(new ArgumentNullException($"Both params: {nameof(coveredByUserIds)}, {nameof(coveredByPartyIds)} cannot be null."));
-                throw new ArgumentNullException($"Both params: {nameof(coveredByUserIds)}, {nameof(coveredByPartyIds)} cannot be null.");
+                activity?.StopWithError(new ArgumentException($"Both params: {nameof(coveredByUserIds)}, {nameof(coveredByPartyIds)} cannot be null."));
+                throw new ArgumentException($"Both params: {nameof(coveredByUserIds)}, {nameof(coveredByPartyIds)} cannot be null.");
             }
 
             string query = string.Empty;
@@ -187,8 +187,8 @@ namespace Altinn.AccessManagement.Persistence
 
             if (coveredByPartyId == null && coveredByUserId == null)
             {
-                activity?.StopWithError(new ArgumentNullException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null."));
-                throw new ArgumentNullException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null.");
+                activity?.StopWithError(new ArgumentException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null."));
+                throw new ArgumentException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null.");
             }
 
             string query = string.Empty;
@@ -376,8 +376,8 @@ namespace Altinn.AccessManagement.Persistence
 
             if (coveredByPartyId == null && coveredByUserId == null)
             {
-                activity?.StopWithError(new ArgumentNullException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null."));
-                throw new ArgumentNullException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null.");
+                activity?.StopWithError(new ArgumentException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null."));
+                throw new ArgumentException($"Both params: {nameof(coveredByUserId)}, {nameof(coveredByPartyId)} cannot be null.");
             }
 
             string query = string.Empty;

--- a/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
+++ b/src/Altinn.AccessManagement.Persistence/DelegationMetadataRepo.cs
@@ -223,7 +223,7 @@ namespace Altinn.AccessManagement.Persistence
                 cmd.Parameters.AddWithNullableValue("coveredByUserId", NpgsqlDbType.Integer, coveredByUserId);
 
                 await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
-                if (reader.Read())
+                if (await reader.ReadAsync(cancellationToken))
                 {
                     return await GetAppDelegationChange(reader);
                 }
@@ -271,7 +271,7 @@ namespace Altinn.AccessManagement.Persistence
                 cmd.Parameters.AddWithValue("blobStorageVersionId", NpgsqlDbType.Text, delegationChange.BlobStorageVersionId);
 
                 using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-                if (reader.Read())
+                if (await reader.ReadAsync(cancellationToken))
                 {
                     return await GetAppDelegationChange(reader);
                 }
@@ -344,7 +344,7 @@ namespace Altinn.AccessManagement.Persistence
                 cmd.Parameters.AddWithValue("delegatedTime", delegationChange.Created.HasValue ? delegationChange.Created.Value : DateTime.UtcNow);
 
                 using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-                if (reader.Read())
+                if (await reader.ReadAsync(cancellationToken))
                 {
                     return await GetResourceRegistryDelegationChange(reader);
                 }
@@ -384,7 +384,7 @@ namespace Altinn.AccessManagement.Persistence
             if (coveredByUserId.HasValue)
             {
                 query = /*strpsql*/@"    
-                SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceid, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
+                SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceRegistryId, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
                 FROM delegation.ResourceRegistryDelegationChanges AS rr
                     JOIN accessmanagement.Resource AS res ON rr.resourceId_fk = res.resourceid
                 WHERE res.resourceRegistryId = @resourceRegistryId AND offeredByPartyId = @offeredByPartyId
@@ -396,7 +396,7 @@ namespace Altinn.AccessManagement.Persistence
             if (coveredByPartyId.HasValue)
             {
                 query = /*strpsql*/@"    
-                SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceid, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
+                SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceRegistryId, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
                 FROM delegation.ResourceRegistryDelegationChanges AS rr
                     JOIN accessmanagement.Resource AS res ON rr.resourceId_fk = res.resourceid
                 WHERE res.resourceRegistryId = @resourceRegistryId AND offeredByPartyId = @offeredByPartyId
@@ -414,7 +414,7 @@ namespace Altinn.AccessManagement.Persistence
                 cmd.Parameters.AddWithNullableValue("coveredByUserId", NpgsqlDbType.Integer, coveredByUserId);
 
                 await using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
-                if (reader.Read())
+                if (await reader.ReadAsync(cancellationToken))
                 {
                     return await GetResourceRegistryDelegationChange(reader);
                 }
@@ -480,7 +480,7 @@ namespace Altinn.AccessManagement.Persistence
                 GROUP BY resourceId_fk, offeredByPartyId, coveredByPartyId, coveredByUserId, R.resourceId, R.resourceRegistryId, R.resourceType
             )
             SELECT
-                change.resourceRegistryDelegationChangeId, change.delegationChangeType, lastChange.resourceRegistryId as resourceid, lastChange.resourceType, change.offeredByPartyId, change.coveredByUserId, change.coveredByPartyId, change.performedByUserId, change.performedByPartyId, change.blobStoragePolicyPath, change.blobStorageVersionId, change.created
+                change.resourceRegistryDelegationChangeId, change.delegationChangeType, lastChange.resourceRegistryId as resourceRegistryId, lastChange.resourceType, change.offeredByPartyId, change.coveredByUserId, change.coveredByPartyId, change.performedByUserId, change.performedByPartyId, change.blobStoragePolicyPath, change.blobStorageVersionId, change.created
             FROM delegation.ResourceRegistryDelegationChanges AS change
                 INNER JOIN lastChange ON change.resourceId_fk = lastChange.resourceid AND change.resourceRegistryDelegationChangeId = lastChange.changeId
             WHERE delegationchangetype != 'revoke_last'
@@ -546,7 +546,7 @@ namespace Altinn.AccessManagement.Persistence
             query += /*strpsql*/@"
                 GROUP BY resourceId_fk, offeredByPartyId, coveredByPartyId, coveredByUserId 
             )
-            SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceid, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
+            SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceRegistryId, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
             FROM delegation.ResourceRegistryDelegationChanges AS rr
                 INNER JOIN res ON rr.resourceId_fk = res.resourceid
                 INNER JOIN active ON rr.resourceRegistryDelegationChangeId = active.changeId
@@ -618,7 +618,7 @@ namespace Altinn.AccessManagement.Persistence
             query += /*strpsql*/@"
                 GROUP BY resourceId_fk, offeredByPartyId, coveredByPartyId, coveredByUserId
             )
-            SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceid, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
+            SELECT rr.resourceRegistryDelegationChangeId, rr.delegationChangeType, res.resourceRegistryId as resourceRegistryId, res.resourceType, rr.offeredByPartyId, rr.coveredByUserId, rr.coveredByPartyId, rr.performedByUserId, rr.performedByPartyId, rr.blobStoragePolicyPath, rr.blobStorageVersionId, rr.created
             FROM delegation.ResourceRegistryDelegationChanges AS rr
                 INNER JOIN res ON rr.resourceId_fk = res.resourceid
                 INNER JOIN active ON rr.resourceRegistryDelegationChangeId = active.changeId
@@ -677,7 +677,7 @@ namespace Altinn.AccessManagement.Persistence
                 GROUP BY DC.resourceId_fk, DC.offeredByPartyId, DC.coveredByPartyId, DC.coveredByUserId, R.resourceId, R.resourceRegistryId, R.resourceType
             )
             SELECT
-                change.resourceRegistryDelegationChangeId, change.delegationChangeType, lastChange.resourceRegistryId as resourceid, lastChange.resourceType,
+                change.resourceRegistryDelegationChangeId, change.delegationChangeType, lastChange.resourceRegistryId as resourceRegistryId, lastChange.resourceType,
                 change.offeredByPartyId, change.coveredByUserId change.coveredByPartyId, change.performedByUserId change.performedByPartyId,
                 change.blobStoragePolicyPath, change.blobStorageVersionId, change.created
             FROM delegation.ResourceRegistryDelegationChanges AS change
@@ -731,7 +731,7 @@ namespace Altinn.AccessManagement.Persistence
                 resourceRegistryDelegationChangeId,
                 null AS delegationChangeId,
                 delegationChangeType,
-                resources.resourceRegistryId as resourceid,
+                resources.resourceRegistryId,
                 resources.resourceType,
                 null AS altinnAppId,
                 offeredByPartyId,
@@ -815,7 +815,7 @@ namespace Altinn.AccessManagement.Persistence
                 resourceRegistryDelegationChangeId,
                 null AS delegationChangeId,
                 delegationChangeType,
-                resources.resourceRegistryId as resourceid,
+                resources.resourceRegistryId,
                 resources.resourceType,
                 null AS altinnAppId,
                 offeredByPartyId,
@@ -835,7 +835,7 @@ namespace Altinn.AccessManagement.Persistence
                 null AS resourceRegistryDelegationChangeId,
                 delegationChangeId,
                 delegationChangeType,
-                null AS resourceRegistryId as resourceid,
+                null AS resourceRegistryId,
                 null AS resourceType,
                 altinnAppId,
                 offeredByPartyId,

--- a/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
+++ b/src/Altinn.AccessManagement.Persistence/Extensions/PersistenceDependencyInjectionExtensions.cs
@@ -70,11 +70,12 @@ public static class PersistenceDependencyInjectionExtensions
         services.TryAddSingleton((IServiceProvider sp) =>
         {
             var settings = sp.GetRequiredService<IOptions<PostgreSQLSettings>>().Value;
-            var connectionString = string.Format(
-                settings.ConnectionString,
-                settings.AuthorizationDbPwd);
 
-            var builder = new NpgsqlDataSourceBuilder(connectionString);
+            var bld = new NpgsqlConnectionStringBuilder(string.Format(settings.ConnectionString, settings.AuthorizationDbPwd));
+            bld.AutoPrepareMinUsages = 2;
+            bld.MaxAutoPrepare = 50;
+
+            var builder = new NpgsqlDataSourceBuilder(bld.ConnectionString);
             builder.UseLoggerFactory(sp.GetRequiredService<ILoggerFactory>());
             builder.MapEnum<DelegationChangeType>("delegation.delegationchangetype");
 

--- a/src/Altinn.AccessManagement.Persistence/ResourceMetadataRepo.cs
+++ b/src/Altinn.AccessManagement.Persistence/ResourceMetadataRepo.cs
@@ -47,7 +47,7 @@ namespace Altinn.AccessManagement.Persistence
                 cmd.Parameters.AddWithValue("resourcetype", NpgsqlDbType.Text, resource.ResourceType.ToString().ToLower());
 
                 using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
-                if (reader.Read())
+                if (await reader.ReadAsync(cancellationToken))
                 {
                     return await GetAccessManagementResource(reader);
                 }
@@ -72,7 +72,7 @@ namespace Altinn.AccessManagement.Persistence
                     ResourceRegistryId = await reader.GetFieldValueAsync<string>("resourceregistryid"),
                     ResourceType = Enum.TryParse(await reader.GetFieldValueAsync<string>("resourcetype"), out ResourceType resourceType) ? resourceType : ResourceType.Default,
                     Created = await reader.GetFieldValueAsync<DateTime>("created"),
-                    Modified = reader.GetFieldValue<DateTime>("modified")
+                    Modified = await reader.GetFieldValueAsync<DateTime>("modified")
                 };
             }
             catch (Exception ex)

--- a/src/Altinn.AccessManagement.Persistence/ResourceMetadataRepo.cs
+++ b/src/Altinn.AccessManagement.Persistence/ResourceMetadataRepo.cs
@@ -2,12 +2,12 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Altinn.AccessManagement.Core.Models;
+using Altinn.AccessManagement.Core.Models.ResourceRegistry;
 using Altinn.AccessManagement.Core.Repositories.Interfaces;
 using Altinn.AccessManagement.Persistence.Configuration;
 using Altinn.AccessManagement.Persistence.Extensions;
-using Dapper;
-using Microsoft.Extensions.Options;
 using Npgsql;
+using NpgsqlTypes;
 
 namespace Altinn.AccessManagement.Persistence
 {
@@ -17,18 +17,15 @@ namespace Altinn.AccessManagement.Persistence
     [ExcludeFromCodeCoverage]
     public class ResourceMetadataRepo : IResourceMetadataRepository
     {
-        private readonly string _connectionString;
+        private readonly NpgsqlDataSource _conn;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceMetadataRepo"/> class
         /// </summary>
-        /// <param name="config">The postgreSQL configurations for AuthorizationDB</param>
-        public ResourceMetadataRepo(IOptions<PostgreSQLSettings> config)
+        /// <param name="conn">PostgreSQL datasource connection</param>
+        public ResourceMetadataRepo(NpgsqlDataSource conn)
         {
-            var bld = new NpgsqlConnectionStringBuilder(string.Format(config.Value.ConnectionString, config.Value.AuthorizationDbPwd));
-            bld.AutoPrepareMinUsages = 2;
-            bld.MaxAutoPrepare = 50;
-            _connectionString = bld.ConnectionString;
+            _conn = conn;
         }
 
         /// <inheritdoc />
@@ -36,28 +33,52 @@ namespace Altinn.AccessManagement.Persistence
         {
             using var activity = TelemetryConfig.ActivitySource.StartActivity(ActivityKind.Client);
 
-            var param = new Dictionary<string, object>();
-            param.Add("resourceregistryid", resource.ResourceRegistryId);
-            param.Add("resourcetype", resource.ResourceType.ToString().ToLower());
-
-            string query =
-            /*strpsql*/"""
+            string query = /*strpsql*/@"
             INSERT INTO accessmanagement.resource (resourceregistryid, resourcetype, created, modified)
             VALUES (@resourceregistryid, @resourcetype, now(), now())
             ON CONFLICT (resourceregistryid) DO UPDATE SET resourcetype = @resourcetype, modified = now()
             RETURNING resourceid, resourceregistryid, resourcetype, created, modified;
-            """;
+            ";
 
             try
             {
-                await using NpgsqlConnection connection = new NpgsqlConnection(_connectionString);
-                var res = await connection.QueryAsync<AccessManagementResource>(new CommandDefinition(query, param, cancellationToken: cancellationToken));
-                return res.FirstOrDefault();
+                await using var cmd = _conn.CreateCommand(query);
+                cmd.Parameters.AddWithValue("resourceregistryid", NpgsqlDbType.Text, resource.ResourceRegistryId);
+                cmd.Parameters.AddWithValue("resourcetype", NpgsqlDbType.Text, resource.ResourceType.ToString().ToLower());
+
+                using NpgsqlDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken);
+                if (reader.Read())
+                {
+                    return await GetAccessManagementResource(reader);
+                }
+
+                return null;
             }
             catch (Exception ex)
             {
                 activity?.StopWithError(ex);
                 throw;
+            }
+        }
+
+        private static async ValueTask<AccessManagementResource> GetAccessManagementResource(NpgsqlDataReader reader)
+        {
+            using var activity = TelemetryConfig.ActivitySource.StartActivity();
+            try
+            {
+                return new AccessManagementResource
+                {
+                    ResourceId = await reader.GetFieldValueAsync<int>("resourceid"),
+                    ResourceRegistryId = await reader.GetFieldValueAsync<string>("resourceregistryid"),
+                    ResourceType = Enum.TryParse(await reader.GetFieldValueAsync<string>("resourcetype"), out ResourceType resourceType) ? resourceType : ResourceType.Default,
+                    Created = await reader.GetFieldValueAsync<DateTime>("created"),
+                    Modified = reader.GetFieldValue<DateTime>("modified")
+                };
+            }
+            catch (Exception ex)
+            {
+                activity?.StopWithError(ex);
+                return await new ValueTask<AccessManagementResource>(Task.FromException<AccessManagementResource>(ex));
             }
         }
     }


### PR DESCRIPTION
## Description
- Added autoprepare to db connectionstring setup in persistance setup
- Removed use of Dapper in ResourceMetadataRepo
- Starte removal of Dapper in Insert methods in DelegationMetadataRepo

## Related Issue(s)
- #558

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
