### PR TITLE
Systemuser token

### DIFF
--- a/src/Altinn.AccessManagement.Core/Constants/AltinnCoreClaimTypes.cs
+++ b/src/Altinn.AccessManagement.Core/Constants/AltinnCoreClaimTypes.cs
@@ -59,5 +59,10 @@
         /// Organization number.
         /// </summary>
         public const string OrgNumber = "urn:altinn:orgNumber";
+
+        /// <summary>
+        /// Authorization details.
+        /// </summary>
+        public const string AuthorizationDetails = "authorization_details";
     }
 }

--- a/src/Altinn.AccessManagement.Core/Helpers/AuthenticationHelper.cs
+++ b/src/Altinn.AccessManagement.Core/Helpers/AuthenticationHelper.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.AccessManagement.Core.Constants;
+﻿using System.Text.Json;
+using Altinn.AccessManagement.Core.Constants;
+using Altinn.AccessManagement.Core.Models;
 using Microsoft.AspNetCore.Http;
 
 namespace Altinn.AccessManagement.Core.Helpers
@@ -54,6 +56,46 @@ namespace Altinn.AccessManagement.Core.Helpers
             }
 
             return 0;
+        }
+
+        /// <summary>
+        /// Gets the users id
+        /// </summary>
+        /// <param name="context">the http context</param>
+        /// <returns>the logged in system users id</returns>
+        public static string GetSystemUserId(HttpContext context)
+        {
+            var claim = context.User?.Claims.FirstOrDefault(c => c.Type.Equals(AltinnCoreClaimTypes.AuthorizationDetails));
+            if (claim != null)
+            {
+                string jwtSystemUSerClaim = claim.Value;
+
+                SystemUserClaim jwtSystemUserClaims = JsonSerializer.Deserialize<SystemUserClaim>(jwtSystemUSerClaim);
+
+                return jwtSystemUserClaims.Systemuser_id[0];
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Returns the system user from the context
+        /// </summary>
+        /// <param name="context">the http context</param>
+        /// <returns>System user object from token</returns>
+        public static SystemUserClaim GetSystemUser(HttpContext context)
+        {
+            var claim = context.User?.Claims.FirstOrDefault(c => c.Type.Equals(AltinnCoreClaimTypes.AuthorizationDetails));
+            if (claim != null)
+            {
+                string jwtSystemUSerClaim = claim.Value;
+
+                SystemUserClaim jwtSystemUserClaims = JsonSerializer.Deserialize<SystemUserClaim>(jwtSystemUSerClaim);
+
+                return jwtSystemUserClaims;
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/src/Altinn.AccessManagement.Core/Models/Token/OrgClaim.cs
+++ b/src/Altinn.AccessManagement.Core/Models/Token/OrgClaim.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.AccessManagement.Core.Models
+{
+    /// <summary>
+    /// Organization claim matching structure from maskinporten
+    /// </summary>
+    public class OrgClaim
+    {
+        /// <summary>
+        /// The authority that defines organization numbers. 
+        /// </summary>
+        [JsonPropertyName("authority")]
+        public string Authority => "iso6523-actorid-upis";
+
+        [JsonPropertyName("ID")]
+        public string ID { get; set; }
+    }
+}

--- a/src/Altinn.AccessManagement.Core/Models/Token/SystemUserClaim.cs
+++ b/src/Altinn.AccessManagement.Core/Models/Token/SystemUserClaim.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.AccessManagement.Core.Models
+{
+    /// <summary>
+    /// System User claim matching structure from maskinporten
+    /// </summary>
+    public class SystemUserClaim
+    {
+        /// <summary>
+        /// The type
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type => "urn:altinn:systemuser";
+
+        /// <summary>
+        /// The organization that created the system user
+        /// </summary>
+        [JsonPropertyName("systemuser_org")]
+        public OrgClaim Systemuser_org { get; set; }
+
+        /// <summary>
+        /// The system user id
+        /// </summary>
+        [JsonPropertyName("systemuser_id")]
+        public List<string> Systemuser_id { get; set; }
+
+        /// <summary>
+        /// The system id
+        /// </summary>
+        [JsonPropertyName("system_id")]
+        public string System_id { get; set; }
+    }
+}

--- a/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
+++ b/src/Altinn.AccessManagement/Controllers/AuthorizedPartiesController.cs
@@ -67,7 +67,8 @@ public class AuthorizedPartiesController : ControllerBase
         try
         {
             int userId = AuthenticationHelper.GetUserId(HttpContext);
-            if (userId == 0)
+            string systemUserID = AuthenticationHelper.GetSystemUserId(HttpContext);
+            if (userId == 0 && string.IsNullOrEmpty(systemUserID))
             {
                 return Unauthorized();
             }

--- a/test/Altinn.AccessManagement.Tests/Controllers/AuthorizedPartiesControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/AuthorizedPartiesControllerTest.cs
@@ -205,6 +205,20 @@ public class AuthorizedPartiesControllerTest : IClassFixture<CustomWebApplicatio
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
+    /// <summary>
+    /// Test to verify systemUser access to authorized parties
+    /// </summary>
+    /// <returns></returns>
+    [Theory]
+    [MemberData(nameof(TestDataAuthorizedParties.SystemUserAuthorizedParty), MemberType = typeof(TestDataAuthorizedParties))]
+    public async Task GetAuthoriedPartiesForSystemUSer(string userToken)
+    {
+        var client = GetTestClient(userToken);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync($"accessmanagement/api/v1/authorizedparties?includeAltinn2=false");
+    }
+
     private static void WithPDPMock(IServiceCollection services) => services.AddSingleton(new PepWithPDPAuthorizationMock());
 
     private HttpClient GetTestClient(string token, params Action<IServiceCollection>[] actions)

--- a/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
+++ b/test/Altinn.AccessManagement.Tests/Data/AuthorizedParties/TestDataAuthorizedParties.cs
@@ -643,6 +643,19 @@ public static class TestDataAuthorizedParties
         }
     };
 
+    /// <summary>
+    /// Test case: Systemuser tries to get list of authorized parties
+    /// Expected: It gets a list
+    /// </summary>
+    /// <returns></returns>
+    public static TheoryData<string> SystemUserAuthorizedParty() => new()
+    {
+        {
+            PrincipalUtil.GetSystemUserToken("ebe4a681-0a8c-429e-a36f-8f9ca942b59f", "314168267", "the_matrix", "314330897")
+        }
+    };
+
+
     private static T GetExpectedResponse<T>(string delegationType, string retrievalType)
     {
         string content = File.ReadAllText($"Data/Json/AuthorizedParties/{delegationType}/{retrievalType}.json");

--- a/test/Altinn.AccessManagement.Tests/Utils/PrincipalUtil.cs
+++ b/test/Altinn.AccessManagement.Tests/Utils/PrincipalUtil.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using Altinn.AccessManagement.Tests.Utils;
 using Altinn.Common.AccessTokenClient.Constants;
 using AltinnCore.Authentication.Constants;
+using Newtonsoft.Json;
 
 namespace Altinn.AccessManagement.Tests.Util
 {
@@ -35,6 +36,18 @@ namespace Altinn.AccessManagement.Tests.Util
             string token = JwtTokenMock.GenerateToken(principal, new TimeSpan(1, 1, 1));
 
             return token;
+        }
+
+        /// <summary>
+        /// Generates a system user token
+        /// </summary>
+        /// <param name="systemUserUuid">The systemUser uid</param>
+        /// <param name="systemUserOrg">The systemUser org</param>
+        /// <param name="systemId">Id for the system. Like Fiken or Business NXT based on systemRegister id</param>
+        /// <param name="consumer">The consumer</param>
+        public static string GetSystemUserToken(string systemUserUuid, string systemUserOrg, string systemId, string consumer)
+        {
+            return JwtTokenMock.GenerateSystemUserToken(systemUserUuid, systemUserOrg, systemId, consumer, new TimeSpan(1, 1, 1));
         }
 
         /// <summary>


### PR DESCRIPTION
Uttesting av systemuser token. 
- Genering av token
- Uthenting av data fra token

Støtter foreløpig ikke i business lag. Må diskuteres hvordan vi tar dette videre

Mest sannsynlig må koden dupliseres inn f.eks i Apps. 