### PR TITLE
fixed failing tests after bruno update

### DIFF
--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinporten/DigDir/digdir-am-k6-read.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinporten/DigDir/digdir-am-k6-read.bru
@@ -29,10 +29,11 @@ vars:pre-request {
   auth_org: digdir
   auth_orgNo: 991825827
   auth_scopes: altinn:maskinporten/delegations.admin
+  bearerToken: 
 }
 
 script:pre-request {
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:maskinporten/delegations.admin"));   
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaOfferedTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaOfferedTest.bru
@@ -36,7 +36,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org1.dagl.pid);
   bru.setVar("party", testdata.org1.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaReceivedTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/getMaskinPortenSchemaReceivedTest.bru
@@ -36,7 +36,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenDAGLCannotDelegateNUFResource.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenDAGLCannotDelegateNUFResource.bru
@@ -58,7 +58,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("to_partyid", testdata.org2.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToOrgNumberSelfTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToOrgNumberSelfTest.bru
@@ -58,7 +58,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("to_orgno", testdata.org1.orgno);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToOrgNumberTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToOrgNumberTest.bru
@@ -58,7 +58,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("to_orgno", testdata.org2.orgno);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToPartyIdSelfTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToPartyIdSelfTest.bru
@@ -58,7 +58,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("to_partyid", testdata.org1.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToPartyIdTest.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/Maskinportenschema/postMaskinportenSchemaToPartyIdTest.bru
@@ -58,7 +58,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("to_partyid", testdata.org2.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o delegate org2org (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o delegate org2org (again).bru
@@ -63,7 +63,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o delegate org2org.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o delegate org2org.bru
@@ -63,7 +63,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o org2org delegation successful.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o org2org delegation successful.bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o receiving org no longer has delegation (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o receiving org no longer has delegation (again).bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o receiving org no longer has delegation.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o receiving org no longer has delegation.bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o receiving org revokes delegation from org.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o receiving org revokes delegation from org.bru
@@ -58,5 +58,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o sending org revokes delegation to org.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o sending org revokes delegation to org.bru
@@ -58,5 +58,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o testdata cleanup (revoke delegation).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2o testdata cleanup (revoke delegation).bru
@@ -56,5 +56,5 @@ script:pre-request {
   bru.setVar("party", testdata.org2.partyid);
   bru.setVar("fromPartyId", testdata.org1.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p delegate org2person (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p delegate org2person (again).bru
@@ -68,7 +68,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p delegate org2person.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p delegate org2person.bru
@@ -68,7 +68,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p org2person delegation successful.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p org2person delegation successful.bru
@@ -26,7 +26,7 @@ script:pre-request {
   bru.setVar("party", testdata.org2.dagl.partyid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p receiving person has no delegation (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p receiving person has no delegation (again).bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p receiving person no longer has delegation.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p receiving person no longer has delegation.bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p receiving person revokes delegation from org.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p receiving person revokes delegation from org.bru
@@ -58,5 +58,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p sending org revokes delegation to person.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p sending org revokes delegation to person.bru
@@ -58,5 +58,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p testdata cleanup (revoke delegation).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/o2p testdata cleanup (revoke delegation).bru
@@ -56,5 +56,5 @@ script:pre-request {
   bru.setVar("party", testdata.org2.partyid);
   bru.setVar("fromPartyId", testdata.org1.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o delegate person2org (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o delegate person2org (again).bru
@@ -63,7 +63,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o delegate person2org.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o delegate person2org.bru
@@ -63,7 +63,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o person2org delegation successful.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o person2org delegation successful.bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o receiving org no longer has delegation (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o receiving org no longer has delegation (again).bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o receiving org no longer has delegation.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o receiving org no longer has delegation.bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o receiving org revokes delegation from person.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o receiving org revokes delegation from person.bru
@@ -58,5 +58,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o sending person revokes delegation to org.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o sending person revokes delegation to org.bru
@@ -58,5 +58,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o testdata cleanup (revoke delegation).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2o testdata cleanup (revoke delegation).bru
@@ -56,5 +56,5 @@ script:pre-request {
   bru.setVar("party", testdata.org2.partyid);
   bru.setVar("fromPartyId", testdata.org1.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p delegate person2person (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p delegate person2person (again).bru
@@ -68,7 +68,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p delegate person2person.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p delegate person2person.bru
@@ -68,7 +68,7 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p delegation successful.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p delegation successful.bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p receiving person has no delegation (again).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p receiving person has no delegation (again).bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p receiving person no longer has delegation.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p receiving person no longer has delegation.bru
@@ -25,7 +25,7 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org2.dagl.pid);
   bru.setVar("party", testdata.org2.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p receiving person revokes delegation.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p receiving person revokes delegation.bru
@@ -58,5 +58,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p testdata cleanup (revoke delegation).bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p testdata cleanup (revoke delegation).bru
@@ -56,5 +56,5 @@ script:pre-request {
   bru.setVar("party", testdata.org2.partyid);
   bru.setVar("fromPartyId", testdata.org1.dagl.partyid);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p the offering person revokes delegation.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal/p2p the offering person revokes delegation.bru
@@ -59,5 +59,5 @@ script:pre-request {
   bru.setVar("org", testdata.org);
   bru.setVar("app", testdata.app);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/o2o delegate org2org A2.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/o2o delegate org2org A2.bru
@@ -61,7 +61,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("to_orgno", testdata.org2.orgno);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/o2p delegate org2person A2.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/o2p delegate org2person A2.bru
@@ -66,7 +66,7 @@ script:pre-request {
   bru.setVar("toSsn", testdata.org2.dagl.pid);
   bru.setVar("toLastName", testdata.org2.dagl.lastname);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/p2o delegate person2org A2.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/p2o delegate person2org A2.bru
@@ -61,7 +61,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("to_orgno", testdata.org2.orgno);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/p2p delegate person2person A2.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/RightsInternal_Altinn2/p2p delegate person2person A2.bru
@@ -68,7 +68,7 @@ script:pre-request {
   bru.setVar("servicecode", testdata.servicecode);
   bru.setVar("serviceeditioncode", testdata.serviceeditioncode);
   
-  await tokenGenerator.getToken();
+  bru.setVar("bearerToken", await tokenGenerator.getToken("altinn:instances.read"));
 }
 
 tests {

--- a/test/Bruno/Altinn.AccessManagement/TestToolsTokenGenerator.js
+++ b/test/Bruno/Altinn.AccessManagement/TestToolsTokenGenerator.js
@@ -1,5 +1,5 @@
 
-exports.getToken = async function () {
+exports.getToken = async function (scopes) {
   const axios = require("axios");
   const btoa = require("btoa");
 
@@ -13,7 +13,7 @@ exports.getToken = async function () {
   const tokenUser = bru.getVar("auth_userId");
   const tokenParty = bru.getVar("auth_partyId");
   const tokenPid = bru.getVar("auth_ssn");
-  const tokenScopes = bru.getVar("auth_scopes");
+  const tokenScopes = scopes;
   const tokenOrg = bru.getVar("auth_org");
   const tokenOrgNo = bru.getVar("auth_orgNo");
   const tokenUsername = bru.getVar("auth_username");
@@ -37,5 +37,5 @@ exports.getToken = async function () {
     headers: { Authorization }
   });
 
-  bru.setVar("bearerToken", response.data);
+  return response.data;
 }


### PR DESCRIPTION
## Description
A Bruno updated made variables scoped within a request inaccessible from outside of it, which caused tests to fail. TestToolTokenGenerator has been updated to work with this new change.

## Related Issue(s)
- https://github.com/orgs/Altinn/projects/50/views/2?pane=issue&itemId=71366106

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
