### PR TITLE
Fix MaskinportenSchema Delegations

### DIFF
--- a/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
@@ -267,7 +267,7 @@ namespace Altinn.AccessManagement.Core.Services
             }
 
             Right right = delegation.Rights.First();
-            DelegationHelper.TryGetResourceFromAttributeMatch(right.Resource, out ResourceAttributeMatchType resourceMatchType, out string resourceRegistryId, out string _, out string _, out string _, out string _);
+            DelegationHelper.TryGetResourceFromAttributeMatch(right.Resource, out ResourceAttributeMatchType resourceMatchType, out string resourceRegistryId, out string org, out string app, out string serviceCode, out string serviceEditionCode);
 
             if (resourceMatchType != ResourceAttributeMatchType.ResourceRegistry)
             {
@@ -276,7 +276,7 @@ namespace Altinn.AccessManagement.Core.Services
             }
 
             // Verify resource registry id is a valid MaskinportenSchema
-            ServiceResource resource = await _contextRetrievalService.GetResource(resourceRegistryId);
+            ServiceResource resource = await _contextRetrievalService.GetResourceFromResourceList(resourceRegistryId, org, app, serviceCode, serviceEditionCode);
             if (resource == null || (delegationAction == DelegationActionType.Delegation && !resource.Delegable))
             {
                 result.Errors.Add("right[0].Resource", $"The resource: {resourceRegistryId}, does not exist or is not available for delegation");

--- a/test/Altinn.AccessManagement.Tests/Data/Resources/resourceList.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Resources/resourceList.json
@@ -1411,5 +1411,208 @@
         "value": "am-devtest-instancedelegation"
       }
     ]
+  },
+  {
+    "title": {
+      "en": "MaskinportenSchema for ValidationProblemDetails responses",
+      "nb-no": "MaskinportenSchema for ValidationProblemDetails responses",
+      "nn-no": "MaskinportenSchema for ValidationProblemDetails responses"
+    },
+    "sector": [
+      "private",
+      "public"
+    ],
+    "status": "Active",
+    "validTo": "2099-12-24T23:59:59",
+    "homepage": "https://www.digdir.no/",
+    "isPartOf": "Altinn",
+    "keywords": [
+    ],
+    "validFrom": "2022-09-20T06:46:07.598Z",
+    "identifier": "mp_validation_problem_details",
+    "isComplete": true,
+    "description": {
+      "en": "A MaskinportenSchema to test ValidationProblemDetails responses",
+      "nb-no": "A MaskinportenSchema to test ValidationProblemDetails responses",
+      "nn-no": "A MaskinportenSchema to test ValidationProblemDetails responses"
+    },
+    "resourceType": "MaskinportenSchema",
+    "thematicArea": "http://publications.europa.eu/resource/authority/eurovoc/2468",
+    "isPublicService": true,
+    "rightDescription": {
+      "en": "Acces to this MaskinportenSchema",
+      "nb-no": "Acces to this MaskinportenSchema",
+      "nn-no": "Acces to this MaskinportenSchema"
+    },
+    "resourceReferences": [
+    ],
+    "hasCompetentAuthority": {
+      "orgcode": "DIGDIR",
+      "organization": "991825827",
+      "name": {
+        "en": "DIGITALISERINGSDIREKTORATET",
+        "nb-no": "DIGITALISERINGSDIREKTORATET",
+        "nn-no": "DIGITALISERINGSDIREKTORATET"
+      }
+    },
+    "authorizationReference": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "mp_validation_problem_details"
+      }
+    ]
+  },
+  {
+    "identifier": "digdirs_company_car",
+    "title": {
+      "en": "DigDir's company car'",
+      "nb-no": "DigDir's company car",
+      "nn-no": "DigDir's company car"
+    },
+    "description": {
+      "en": "Only the manager (DAGL) has access to drive the company car",
+      "nb-no": "Bare daglig leder (DAGL) har tilgang til � kj�re firmabilen",
+      "nn-no": "Berre dagleg leiar (DAGL) har h�ve til � kj�yre firmabilen"
+    },
+    "rightDescription": {
+      "en": "Gives an employee permission to borrow the company car",
+      "nb-no": "Gir en ansatt lov til � l�ne firmabilen",
+      "nn-no": "Gjev ein tilsett l�yve til � ta ei r�nerunde ned i vik"
+    },
+    "homepage": "https://www.jksfirmabiler.no/",
+    "status": "Active",
+    "validFrom": "2022-09-20T06:46:07.598Z",
+    "validTo": "2099-12-24T23:59:59",
+    "isPartOf": "jk_ressurser",
+    "isPublicService": true,
+    "thematicArea": "http://publications.europa.eu/resource/authority/eurovoc/2468",
+    "resourceReferences": [
+      {
+        "referenceSource": "Altinn3",
+        "reference": "urn:altinn:resource:digdirs_company_car",
+        "referenceType": "Uri"
+      }
+    ],
+    "isComplete": true,
+    "hasCompetentAuthority": {
+      "organization": "991825827",
+      "orgcode": "DIGDIR"
+    },
+    "keywords": [
+      {
+        "word": "bil",
+        "language": "nb"
+      }
+    ],
+    "sector": [
+      "offentlig"
+    ],
+    "resourceType": "MaskinportenSchema",
+    "authorizationReference": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "digdirs_company_car"
+      }
+    ]
+  },
+  {
+    "title": {
+      "en": "A System Resource",
+      "nb-no": "A System Resource",
+      "nn-no": "A System Resource"
+    },
+    "sector": [
+      "private",
+      "public"
+    ],
+    "status": "Active",
+    "validTo": "2099-12-24T23:59:59",
+    "homepage": "https://www.digdir.no/",
+    "isPartOf": "Altinn",
+    "keywords": [
+    ],
+    "validFrom": "2022-09-20T06:46:07.598Z",
+    "identifier": "system_resource",
+    "isComplete": true,
+    "description": {
+      "en": "Random System Resource",
+      "nb-no": "Random System Resource",
+      "nn-no": "Random System Resource"
+    },
+    "resourceType": "SystemResource",
+    "thematicArea": "http://publications.europa.eu/resource/authority/eurovoc/2468",
+    "isPublicService": true,
+    "rightDescription": {
+      "en": "Acces to this random system resource",
+      "nb-no": "Acces to this random system resource",
+      "nn-no": "Acces to this random system resource"
+    },
+    "resourceReferences": [
+    ],
+    "hasCompetentAuthority": {
+      "orgcode": "DIGDIR",
+      "organization": "991825827",
+      "name": {
+        "en": "DIGITALISERINGSDIREKTORATET",
+        "nb-no": "DIGITALISERINGSDIREKTORATET",
+        "nn-no": "DIGITALISERINGSDIREKTORATET"
+      }
+    },
+    "authorizationReference": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "system_resource"
+      }
+    ]
+  },
+  {
+    "title": {
+      "en": "MaskinportenSchema that cannot be delegated",
+      "nb-no": "MaskinportenSchema that cannot be delegated",
+      "nn-no": "MaskinportenSchema that cannot be delegated"
+    },
+    "sector": [
+      "private",
+      "public"
+    ],
+    "status": "Active",
+    "validTo": "2099-12-24T23:59:59",
+    "homepage": "https://www.digdir.no/",
+    "isPartOf": "Altinn",
+    "keywords": [
+    ],
+    "validFrom": "2022-09-20T06:46:07.598Z",
+    "identifier": "non_delegable_maskinportenschema",
+    "isComplete": true,
+    "description": {
+      "en": "A MaskinportenSchema with a RoleRequirement (NOPE) to a role which does not exist and so cannot be delegated",
+      "nb-no": "A MaskinportenSchema with a RoleRequirement (NOPE) to a role which does not exist and so cannot be delegated",
+      "nn-no": "A MaskinportenSchema with a RoleRequirement (NOPE) to a role which does not exist and so cannot be delegated"
+    },
+    "resourceType": "MaskinportenSchema",
+    "thematicArea": "http://publications.europa.eu/resource/authority/eurovoc/2468",
+    "isPublicService": true,
+    "rightDescription": {
+      "en": "Not delegable",
+      "nb-no": "Not delegable",
+      "nn-no": "Not delegable"
+    },
+    "resourceReferences": [
+    ],
+    "hasCompetentAuthority": {
+      "orgcode": "DIGDIR",
+      "organization": "991825827",
+      "name": {
+        "en": "DIGITALISERINGSDIREKTORATET",
+        "nb-no": "DIGITALISERINGSDIREKTORATET",
+        "nn-no": "DIGITALISERINGSDIREKTORATET"
+      }
+    },
+    "authorizationReference": [
+      {
+        "id": "urn:altinn:resource",
+        "value": "non_delegable_maskinportenschema"
+      }
+    ]
   }
 ]

--- a/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/AppsInstanceDelegation/DelegationCheck/AppWithDelegableRights_Ok.bru
+++ b/test/Bruno/Altinn.AccessManagement/Automatic Test Collection/AppsInstanceDelegation/DelegationCheck/AppWithDelegableRights_Ok.bru
@@ -45,10 +45,12 @@ script:pre-request {
 tests {
   test("AppsInstanceDelegation DelegationCheck GET AppWithDelegableRights_Ok", function() {
     var body = res.getBody();
+    var data = body.data;
+    console.log(data);
     expect(res.status).to.equal(200);
-    expect(body[0]).to.have.property('rightKey', 'authz-bruno-instancedelegation,ttd,task_1:read')
-    expect(body[0]).to.have.property('status', 'Delegable')
-    expect(body[1]).to.have.property('rightKey', 'authz-bruno-instancedelegation,ttd,task_1:sign')
-    expect(body[1]).to.have.property('status', 'Delegable')
+    expect(data[0]).to.have.property('rightKey', 'app_ttd_authz-bruno-instancedelegation,task_1:read')
+    expect(data[0]).to.have.property('status', 'Delegable')
+    expect(data[1]).to.have.property('rightKey', 'app_ttd_authz-bruno-instancedelegation,task_1:sign')
+    expect(data[1]).to.have.property('status', 'Delegable')
   });
 }


### PR DESCRIPTION
Because of change in 
RightsHelper.GetRightsQuery now takes the full ServiceResource model as input to build the rights query, based on the resource's 'authorizationReference' property.

Since the ValidateMaskinportenDelegationModel method use the GET resource/{resourceId} endpoint in ResourceRegistry (which apparently don't return the 'authorizationReference' property), API delegations now fail.

Fix: Updated ValidateMaskinportenDelegationModel  method to also use the ResourceList API endpoint, same as the DelegationCheck operation does.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{insert issue number here}

## Developer/Reviewer Checklist
- [x] **Your** code builds clean without any errors or warnings
- [x] No changes to config/appsettings or environment variables created in separate linked PR
- [x] Manual testing done (required)
- [x] Relevant integration test added (required for functional changes)
- [x] Relevant automated test added (required for functional changes)
- [x] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
