### PR TITLE
Remove duplicate Delegable check

### DIFF
--- a/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
+++ b/src/Altinn.AccessManagement.Core/Services/MaskinportenSchemaService.cs
@@ -289,12 +289,6 @@ namespace Altinn.AccessManagement.Core.Services
                 return (result, null, null, null);
             }
 
-            if (!resource.Delegable)
-            {
-                result.Errors.Add("right[0].Resource", $"The resource: {resource}, is not available for delegation");
-                return (result, null, null, null);
-            }
-
             // Verify and get From reportee party of the delegation
             Party fromParty = null;
             if (DelegationHelper.TryGetOrganizationNumberFromAttributeMatch(delegation.From, out string fromOrgNo))

--- a/test/Altinn.AccessManagement.Tests/Controllers/MaskinportenSchemaControllerTest.cs
+++ b/test/Altinn.AccessManagement.Tests/Controllers/MaskinportenSchemaControllerTest.cs
@@ -1294,6 +1294,31 @@ namespace Altinn.AccessManagement.Tests.Controllers
         }
 
         /// <summary>
+        /// Test case: RevokeActiveMaskinportenScopeDelegation performed by authenticated user 20001337 for the reportee party 50004221 of the non-delegable altinn_access_management maskinporten schema resource from the resource registry,
+        ///            which have received delegation from the party 50005545
+        ///            In this case:
+        ///            - The user 20001337 is DAGL for the To unit 50004221
+        /// Expected: RevokeActiveMaskinportenScopeDelegation returns 204 No Content
+        /// </summary>
+        [Fact]
+        public async Task RevokeActiveMaskinportenScopeDelegation_ResourceDelegableFalse_Success()
+        {
+            // Arrange
+            string toParty = "50004221";
+            DelegationMetadataRepositoryMock delegationMetadataRepositoryMock = new DelegationMetadataRepositoryMock { MetadataChanges = new Dictionary<string, List<DelegationChange>>() };
+            HttpClient client = GetTestClient(delegationMetadataRepositoryMock: delegationMetadataRepositoryMock);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetToken(20001337, 50001337));
+
+            StreamContent requestContent = GetRequestContent("RevokeReceivedMaskinportenScopeDelegation", "jks_undelegable", $"p50005545", $"p{toParty}");
+
+            // Act
+            HttpResponseMessage response = await client.PostAsync($"accessmanagement/api/v1/{toParty}/maskinportenschema/received/revoke", requestContent);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        }
+
+        /// <summary>
         /// Test case: RevokeReceivedMaskinportenScopeDelegation performed by authenticated user 20001337 for the reportee organization 810418532 of the jks_audi_etron_gt maskinporten schema resource from the resource registry,
         ///            which have received delegation from the party 50005545
         ///            In this case:

--- a/test/Altinn.AccessManagement.Tests/Data/Json/MaskinportenSchema/RevokeReceivedMaskinportenScopeDelegation/jks_undelegable/from_p50005545/to_p50004221/Input_Default.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Json/MaskinportenSchema/RevokeReceivedMaskinportenScopeDelegation/jks_undelegable/from_p50005545/to_p50004221/Input_Default.json
@@ -1,0 +1,18 @@
+{
+  "from": [
+    {
+      "id": "urn:altinn:partyid",
+      "value": "50005545"
+    }
+  ],
+  "rights": [
+    {
+      "resource": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "jks_undelegable"
+        }
+      ]
+    }
+  ]
+}

--- a/test/Altinn.AccessManagement.Tests/Data/Resources/resourceList.json
+++ b/test/Altinn.AccessManagement.Tests/Data/Resources/resourceList.json
@@ -225,8 +225,8 @@
     "isPartOf": "jk_ressurser",
     "isPublicService": true,
     "resourceReferences": [],
-    "delegable": true,
-    "visible": true,
+    "delegable": false,
+    "visible": false,
     "hasCompetentAuthority": {
       "organization": "991825827",
       "orgcode": "DIGDIR",
@@ -249,7 +249,7 @@
     "authorizationReference": [
       {
         "id": "urn:altinn:resource",
-        "value": "jks_audi_a3"
+        "value": "jks_undelegable"
       }
     ]
   },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Duplicate check on resource.Delegable which blocks users from revoking existing active delegations after a resource has been deactivated for new delegations. This should however not block revoke of delgations.

## Related Issue(s)
https://github.com/Altinn/altinn-authorization-tmp/issues/89

## Developer/Reviewer Checklist
- [ ] **Your** code builds clean without any errors or warnings
- [ ] No changes to config/appsettings or environment variables created in separate linked PR
- [ ] Manual testing done (required)
- [ ] Relevant integration test added (required for functional changes)
- [ ] Relevant automated test added (required for functional changes)
- [ ] All integration tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
